### PR TITLE
Use reusable workflow from hyperspy organisation for the doc workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,97 +1,17 @@
-name: Docs
+name: Documentation
 
 on: [push, pull_request]
 
 jobs:
-  build_docs:
-    # This build is to make PR comments for the sphinx warning and check if
-    # web links are not broken 
-    name: Check links and make PR comments
-    runs-on: ubuntu-latest
-    env:
-      DOCS_PATH: ./doc/_build/html/
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  Build:
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/doc.yml@main
 
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.11'
-
-      - name: Install build docs
-        shell: bash -l {0}
-        run: |
-          pip install .'[doc]'
-      
-      # Add sphinx warnings as PR comments
-      - uses: sphinx-doc/sphinx-problem-matcher@master
-
-      - name: Build docs
-        shell: bash -l {0}
-        run: |
-          cd doc
-          make SPHINXOPTS="-W --keep-going" html
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.DOCS_PATH }}
-          name: docs_html
-
-      - name: Check links
-        shell: bash -l {0}
-        run: |
-          cd doc
-          make linkcheck
-
-  push_docs:
-    # This build is to push changes to gh-pages branch (https://hyperspy.org/exspy)
-    needs: build_docs
-    name: Push to gh-pages
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'hyperspy/exspy' }}
+  Push:
+    needs: Build
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'hyperspy' }}
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: gh-pages
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: docs_html
-          path: .
-
-      - name: list files
-        run: |
-          ls
-
-      - name: Git status
-        run: |
-          git status
-          git status -s
-          if [[ $(git status -s) ]]; then
-            HAS_CHANGES='true'
-          else
-            HAS_CHANGES='false'
-          fi
-          echo "HAS_CHANGES=${HAS_CHANGES}" >> $GITHUB_ENV
-
-      - name: Commit files
-        # Skip when there is nothing to commit
-        if: ${{ env.HAS_CHANGES == 'true' }}
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add -A
-          git commit -m "Update docs build" -a
-
-      - name: Push changes
-        if: ${{ env.HAS_CHANGES == 'true' }}
-        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/push_doc.yml@main

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ https://holospy.readthedocs.io/en/latest/changes.html
   usable dataset is downloaded from `doi:10.5281/zenodo.7645765 <https://zenodo.org/record/6599071>`_
   (`HyperSpy #3082 <https://github.com/hyperspy/hyperspy/issues/3082>`_)
 - Add functionality to fit the :ref:`EELS fine structure <eels.fine_structure>` using components, e.g. :py:class:`hyperspy.api.model.components1D.Gaussian`. (`HyperSpy #3206 <https://github.com/hyperspy/hyperspy/issues/3206>`_)
-
+- Use reusable workflow from the hyperspy organisation for the doc workflow (`#13 <https://github.com/hyperspy/exspy/pull/13>`_)
 
 Initiation (2023-10-28)
 =======================


### PR DESCRIPTION
This would simplify the maintenance of GitHub CI.

### Progress of the PR
- [x] Use reusable workflow from hyperspy organisation for the doc workflow,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] added line to CHANGES.rst,
- [x] ready for review.



