### PR TITLE
Release0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,28 +14,13 @@ on:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  build:
-    name: Build wheel and sdist
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Run build
-      run: |
-        pipx run build
-
-    - name: Display built files
-      run: |
-        ls -shR
-      working-directory: dist
-
-    - uses: actions/upload-artifact@v3
-      with:
-        path: dist/*
-        name: artifacts
+  package_and_test:
+    name: Package and Test
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
 
   upload_to_pypi:
-    needs: [build]
+    needs: [package_and_test]
     runs-on: ubuntu-latest
     name: Upload to pypi
     permissions:
@@ -44,9 +29,6 @@ jobs:
     steps:
     - name: Download dist
       uses: actions/download-artifact@v3
-      with:
-        name: artifacts
-        path: dist
 
     - name: Display downloaded files
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,19 +9,32 @@ https://exspy.readthedocs.io/en/latest/changes.html
 
 .. towncrier release notes start
 
-- Enable ``signal_range`` arguments when using ``subpixel=True`` in :py:meth:`~.signals.EELSSpectrum.align_zero_loss_peak` (`#7 <https://github.com/hyperspy/exspy/pull/7>`_)
+0.1 (2023-12-03)
+================
+
+New features
+------------
 - Support for tabulated :ref:`Generalised Oscillator Strengths (GOS) <eels.GOS>` using the
   `GOSH <https://gitlab.com/gguzzina/gosh>`_ open file format. By default, a freely
   usable dataset is downloaded from `doi:10.5281/zenodo.7645765 <https://zenodo.org/record/6599071>`_
   (`HyperSpy #3082 <https://github.com/hyperspy/hyperspy/issues/3082>`_)
 - Add functionality to fit the :ref:`EELS fine structure <eels.fine_structure>` using components, e.g. :py:class:`hyperspy.api.model.components1D.Gaussian`. (`HyperSpy #3206 <https://github.com/hyperspy/hyperspy/issues/3206>`_)
+
+Enhancements
+------------
+
+- Enable ``signal_range`` arguments when using ``subpixel=True`` in :py:meth:`~.signals.EELSSpectrum.align_zero_loss_peak` (`#7 <https://github.com/hyperspy/exspy/pull/7>`_)
+
+Maintenance
+-----------
+
+- Use towncrier to manage release notes and improve setting dev version (`#14 <https://github.com/hyperspy/exspy/issues/14>`_)
 - Use reusable workflow from the hyperspy organisation for the doc workflow (`#13 <https://github.com/hyperspy/exspy/pull/13>`_)
 - Consolidate packaging metadata in ``pyproject.toml``. (`#4 <https://github.com/hyperspy/exspy/pull/4>`_, `#10 <https://github.com/hyperspy/exspy/pull/10>`_)
 - Use ``setuptools_scm`` to set holospy version at build time (`#10 <https://github.com/hyperspy/exspy/pull/10>`_)
 - Add package and test workflow (`#10 <https://github.com/hyperspy/exspy/pull/10>`_)
 - Add python 3.12 (`#10 <https://github.com/hyperspy/exspy/pull/10>`_)
 - Add release workflow (`#10 <https://github.com/hyperspy/exspy/pull/10>`_)
-
 
 Initiation (2023-10-28)
 =======================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ include = ["exspy*"]
 [tool.setuptools_scm]
 # Presence enables setuptools_scm, the version will be determine at build time from git
 # The version will be updated by the `prepare_release.py` script
-fallback_version = "0.1.dev0"
+fallback_version = "0.2.dev0"
 
 
 [tool.towncrier]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,8 @@ exspy = "exspy"
 file = "LICENSE"
 
 [project.optional-dependencies]
-"gui-jupyter" = [
-  "hyperspy_gui_ipywidgets @ https://github.com/hyperspy/hyperspy_gui_ipywidgets/archive/hyperspy2.0.zip",
-]
-"gui-traitsui" = [
-  "hyperspy_gui_traitsui @ https://github.com/hyperspy/hyperspy_gui_traitsui/archive/hyperspy2.0.zip",
-]
+"gui-jupyter" = ["hyperspy_gui_ipywidgets>=2.0"]
+"gui-traitsui" = ["hyperspy_gui_traitsui>=2.0"]
 "doc" = [
   "numpydoc",
   "pydata-sphinx-theme>=0.13",

--- a/upcoming_changes/14.maintenance.rst
+++ b/upcoming_changes/14.maintenance.rst
@@ -1,1 +1,0 @@
-Use towncrier to manage release notes and improve setting dev version


### PR DESCRIPTION
https://github.com/hyperspy/exspy/blob/main/releasing_guide

- Simplify release workflow,
- update `hyperspy_gui_*` dependencies, 
- update release notes.

