### PR TITLE
Use `cumulative_trapezoid` instead of  `cumtrapz`

### DIFF
--- a/exspy/signals/dielectric_function.py
+++ b/exspy/signals/dielectric_function.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 from scipy import constants
-from scipy.integrate import simpson, cumtrapz
+from scipy.integrate import simpson, cumulative_trapezoid
 
 from hyperspy._signals.complex_signal1d import (
     ComplexSignal1D,
@@ -95,7 +95,7 @@ class DielectricFunction(ComplexSignal1D):
         else:
             neff1 = self._deepcopy_with_new_data(
                 k
-                * cumtrapz(
+                * cumulative_trapezoid(
                     (-1.0 / self.data).imag * axis.axis,
                     x=axis.axis,
                     axis=axis.index_in_array,
@@ -104,7 +104,7 @@ class DielectricFunction(ComplexSignal1D):
             )
             neff2 = self._deepcopy_with_new_data(
                 k
-                * cumtrapz(
+                * cumulative_trapezoid(
                     self.data.imag * axis.axis,
                     x=axis.axis,
                     axis=axis.index_in_array,


### PR DESCRIPTION
In https://github.com/hyperspy/exspy/pull/33, I missed one deprecation (see https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/8612136996/job/23600692746).

I couldn't find it in the scipy release notes but the relevant issue/PR are https://github.com/scipy/scipy/issues/18702 and https://github.com/scipy/scipy/pull/18699.

### Progress of the PR
- [x] Use `cumulative_trapezoid` instead of  `cumtrapz`,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.


