### PR TITLE
Set  the fine structure coefficients only if not already set when adding `EELSCLEdge` to a model

### DIFF
--- a/exspy/models/eelsmodel.py
+++ b/exspy/models/eelsmodel.py
@@ -335,7 +335,11 @@ class EELSModel(Model1D):
                 energy_scale=self.axis.scale,
             )
             component.energy_scale = self.axis.scale
-            component._set_fine_structure_coeff()
+            # Only set the fine structure if it is not already set
+            # This is useful when adding components fitted with
+            # a model to a different model
+            if component.fine_structure_coeff.map is None:
+                component._set_fine_structure_coeff()
         self._classify_components()
 
     append.__doc__ = Model1D.append.__doc__


### PR DESCRIPTION
### Description of the change

Fix a regression that resets the `fine_structure_coeff` when adding a `EELSCLEdge` to an `EELSModel`.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] added tests,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import exspy
import numpy as np
s = exspy.signals.EELSSpectrum(np.arange(100).reshape(10,10))
# Your new feature...
```


