### PR TITLE
`fit_background` fixes

### DIFF
--- a/exspy/models/edsmodel.py
+++ b/exspy/models/edsmodel.py
@@ -180,10 +180,6 @@ class EDSModel(Model1D):
                 "but an object of type %s was provided" % str(type(value))
             )
 
-    @property
-    def _active_xray_lines(self):
-        return [xray_line for xray_line in self.xray_lines if xray_line.active]
-
     def add_family_lines(self, xray_lines="from_elements"):
         """Create the Xray-lines instances and configure them appropiately
 
@@ -320,13 +316,15 @@ class EDSModel(Model1D):
 
     def enable_xray_lines(self):
         """Enable the X-ray lines components."""
-        for component in self.xray_lines:
-            component.active = True
+        for component in self:
+            if not component.isbackground:
+                component.active = True
 
     def disable_xray_lines(self):
         """Disable the X-ray lines components."""
-        for component in self._active_xray_lines:
-            component.active = False
+        for component in self:
+            if not component.isbackground:
+                component.active = False
 
     def _make_position_adjuster(self, component, fix_it, show_label):
         # Override to ensure formatting of labels of xray lines

--- a/exspy/models/edsmodel.py
+++ b/exspy/models/edsmodel.py
@@ -914,12 +914,8 @@ class EDSModel(Model1D):
                 data_res = data_res[0]
             img = self.signal.isig[0:1].integrate1D(-1)
             img.data = data_res
-            img.metadata.General.title = "Intensity of %s at %.2f %s from %s" % (
-                xray_line,
-                line_energy,
-                self.signal.axes_manager.signal_axes[0].units,
-                self.signal.metadata.General.title,
-            )
+            units = self.signal.axes_manager.signal_axes[0].units
+            img.metadata.General.title = f"{xray_line} at {line_energy:.2f} {units}"
             img = img.transpose(signal_axes=[])
             if plot_result and img.axes_manager.signal_dimension == 0:
                 print(

--- a/exspy/tests/models/test_edsmodel.py
+++ b/exspy/tests/models/test_edsmodel.py
@@ -110,6 +110,18 @@ class TestlineFit:
         self.s.set_signal_type("EDS_TEM")
         self._check_model_store()
 
+    def test_disable_xray_lines(self):
+        m = s.create_model()
+        for c in m:
+            assert c.active
+        m.disable_xray_lines()
+        assert m[0].active
+        for c in m[1:]:
+            assert not c.active
+        m.enable_xray_lines()
+        for c in m:
+            assert c.active
+
     def test_calibrate_energy_resolution(self):
         s = self.s
         m = s.create_model()

--- a/exspy/tests/models/test_linear_model.py
+++ b/exspy/tests/models/test_linear_model.py
@@ -92,6 +92,11 @@ class TestTwinnedComponents:
         np.testing.assert_allclose(nonlinear_fit.data, lstsq_fit.data)
         np.testing.assert_allclose(nonlinear_std, linear_std)
 
+    def test_fit_background(self):
+        m2 = self.m2
+        m2.fit_background(optimizer="lstsq")
+        np.testing.assert_allclose(m2[0].a0.value, 11045209.18)
+
 
 class TestWarningSlowMultifit:
     def setup_method(self, method):

--- a/exspy/tests/models/test_linear_model.py
+++ b/exspy/tests/models/test_linear_model.py
@@ -97,6 +97,17 @@ class TestTwinnedComponents:
         m2.fit_background(optimizer="lstsq")
         np.testing.assert_allclose(m2[0].a0.value, 11045209.18)
 
+    def test_fit_background_reset_signal_range(self):
+        m2 = self.m2
+        m2.remove_signal_range(7.0, 8.0)
+        np.testing.assert_allclose(m2._channel_switches[:200], True)
+        np.testing.assert_allclose(m2._channel_switches[301:], True)
+        np.testing.assert_allclose(m2._channel_switches[200:301], False)
+        m2.fit_background(optimizer="lstsq")
+        np.testing.assert_allclose(m2._channel_switches[:200], True)
+        np.testing.assert_allclose(m2._channel_switches[301:], True)
+        np.testing.assert_allclose(m2._channel_switches[200:301], False)
+
 
 class TestWarningSlowMultifit:
     def setup_method(self, method):

--- a/upcoming_changes/76.bugfix.rst
+++ b/upcoming_changes/76.bugfix.rst
@@ -1,0 +1,5 @@
+:meth:`exspy.models.EDSModel.fit_background` fixes:
+
+- fix error when using linear fitting,
+- fix resetting signal range after fitting background,
+- suspend plot when fitting background.


### PR DESCRIPTION
Fitting the background in EDS model doesn't work with linear fitting, because the twin lines are disactivated properly when running linear fitting.

```python
import exspy

s = exspy.data.EDS_SEM_TM002()
m = s.isig[5.0:15.0].create_model()
m.plot()
m.fit_background(optimizer="lstsq")
```
which will raise the following error:
```python
    m.fit_background(optimizer="lstsq")

  File ~\Dev\exspy\exspy\models\edsmodel.py:394 in fit_background
    self.fit(**kwargs)

  File ~\Dev\hyperspy\hyperspy\model.py:1797 in fit
    fit_output = self._linear_fit(

  File ~\Dev\hyperspy\hyperspy\model.py:1217 in _linear_fit
    index = parameters.index(p)

ValueError: <Parameter A of Cu_Ka component> is not in list
```


### Progress of the PR
- [x] Fix `fit_background` with linear fitting,
- [x] fix resetting signal range after fitting background,
- [x] suspend plot when fitting background, 
- [x] simplify/shorten title of EDS maps, 
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

