### PR TITLE
Add link to Tutorial to User Guide

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,6 +100,12 @@ html_theme_options = {
         "image_light": "_static/exspy-banner-light.svg",
         "image_dark": "_static/exspy-banner-dark.svg",
     },
+    "external_links": [
+        {
+            "url": "https://github.com/hyperspy/exspy-demos",
+            "name": "Tutorial",
+        },
+    ],
     "header_links_before_dropdown": 6,
     "navigation_with_keys": False,
 }


### PR DESCRIPTION
Just realized during tutorials that there is no link to the `exspy-demos` repository in the navigation header of the doc website. Adapting it to match with the hyperspy docs.

- [x] Change implemented
- [x] Checked rendering of docs