### PR TITLE
Fix import

### DIFF
--- a/exspy/_misc/eels/hartree_slater_gos.py
+++ b/exspy/_misc/eels/hartree_slater_gos.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import numpy as np
 from scipy import constants
 
-from hyperspy.defaults_parser import preferences
+from exspy._defaults_parser import preferences
 from exspy._misc.eels.base_gos import TabulatedGOS
 
 

--- a/exspy/misc/elements.py
+++ b/exspy/misc/elements.py
@@ -6,10 +6,11 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 
 from exspy._misc.elements import elements_db
 
+# atomap still using elements
+elements = elements_db
 
-__all__ = [
-    "elements_db",
-]
+
+__all__ = ["elements_db", "elements"]
 
 
 def __dir__():

--- a/upcoming_changes/90.bugfix.rst
+++ b/upcoming_changes/90.bugfix.rst
@@ -1,0 +1,1 @@
+Fix preferences import when using Hartree-Slater GOS and re-introduce undocumented import used by ``atomap``.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix undocumented API that fall through the cracks in #59 and is used in atomap.
- [x] Fix preferences import when `hartree-slater` GOS as reported in https://github.com/hyperspy/exspy/issues/20#issuecomment-2407967639. 
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

@CSSFrancis, @jlaehne, I think we should make a patch release straightaway since atomap is using one of these import.


