### PR TITLE
Add numba to speed dependencies

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,7 +52,7 @@ linkcheck_ignore = [
     "https://onlinelibrary.wiley.com/doi/10.1111/j.1365-2818.2006.01549.x",  # 403 Client Error: Forbidden for url
     "https://onlinelibrary.wiley.com/doi/10.1002/sia.5789",  # 403 Client Error: Forbidden for url
     "https://onlinelibrary.wiley.com/doi/10.1002/jemt.20597",  # 403 Client Error: Forbidden for url
-    "https://doi.org/10.1017/S1431927615015494", # 403 Client Error: Forbidden for url
+    "https://doi.org/10.1017/S1431927615015494",  # 403 Client Error: Forbidden for url
 ]
 
 intersphinx_mapping = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,7 @@ file = "LICENSE"
   "towncrier<24",
 ]
 speed = [
-    "numba>=0.53",
-    "numexpr>=2.8",
+    "hyperspy[speed]",
 ]
 "tests" = [
   "pytest     >= 5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ file = "LICENSE"
   # unpin when sphinxcontrib-towncrier support more recent version to towncrier
   "towncrier<24",
 ]
-"speed" = ["numexpr"]
+speed = [
+    "numba>=0.53",
+    "numexpr>=2.8",
+]
 "tests" = [
   "pytest     >= 5.0",
   "pytest-mpl",


### PR DESCRIPTION
Add numba to speed dependencies to fix failing tests and align minimum requirements with those of hyperspy. 