### PR TITLE
Drop support python 3.8 and add explicit support for python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,18 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        PYTHON_VERSION: ['3.9', '3.11']
+        PYTHON_VERSION: ['3.10', '3.12']
         LABEL: ['']
         PIP_SELECTOR: ['[tests, speed]']
         include:
           - os: ubuntu
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.9'
             PIP_SELECTOR: '[tests, speed]'
           - os: ubuntu
-            PYTHON_VERSION: '3.10'
+            PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[tests, speed]'
           - os: ubuntu
-            PYTHON_VERSION: '3.12'
+            PYTHON_VERSION: '3.13'
             PIP_SELECTOR: '[tests, speed]'
           # test with hyperspy dev branch
           - os: ubuntu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "exspy"
 description = "EELS and EDS analysis with the HyperSpy framework"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 keywords=[
     "python",
@@ -32,16 +32,15 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "dask[array]",
-  # Release 0.3.1, needs new hyperspy release which includes https://github.com/hyperspy/hyperspy/pull/3494
-  "hyperspy>=2.0rc0",
+  "hyperspy>=2.3.0",
   "matplotlib",
   "numpy",
   "pint",

--- a/upcoming_changes/108.maintenance.rst
+++ b/upcoming_changes/108.maintenance.rst
@@ -1,0 +1,1 @@
+Drop support python 3.8 and add explicit support for python 3.13.


### PR DESCRIPTION
### Progress of the PR
- [x] Drop support python 3.8,
- [x] add explicit support for python 3.13,
- [x] update test matrix, 
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [ ] ready for review.


