### PR TITLE
Clean up some tests after split

### DIFF
--- a/exspy/tests/components/test_double_power_law.py
+++ b/exspy/tests/components/test_double_power_law.py
@@ -52,7 +52,6 @@ class TestDoublePowerLaw:
         s.axes_manager[0].offset = 100
         s.axes_manager[0].scale = 0.1
         m = s.create_model()
-
         m.append(DoublePowerLaw())
         m[0].A.value = 1000
         m[0].r.value = 4
@@ -65,8 +64,7 @@ class TestDoublePowerLaw:
         self.m.signal.axes_manager[-1].is_binned = binned
         s = self.m.as_signal()
         assert s.axes_manager[-1].is_binned == binned
-        exspy = pytest.importorskip("exspy")
-        g = exspy.components.DoublePowerLaw()
+        g = DoublePowerLaw()
         # Fix the ratio parameter to test the fit
         g.ratio.free = False
         g.shift.free = False

--- a/exspy/tests/drawing/test_plot_model.py
+++ b/exspy/tests/drawing/test_plot_model.py
@@ -130,7 +130,6 @@ def test_plot_gaussian_EELSSpectrum(convolved, plot_component, binned):
 @pytest.mark.mpl_image_compare(baseline_dir=baseline_dir, tolerance=default_tol)
 def test_fit_EELS_convolved(convolved):
     # Keep this test here to avoid having to add image comparison in exspy
-    pytest.importorskip("exspy", reason="exspy not installed.")
     dname = my_path.joinpath("data")
     with pytest.warns(VisibleDeprecationWarning):
         cl = hs.load(dname.joinpath("Cr_L_cl.hspy"))

--- a/exspy/tests/signals/test_assign_subclass.py
+++ b/exspy/tests/signals/test_assign_subclass.py
@@ -92,7 +92,6 @@ class Test2d:
         self.s = hs.signals.BaseSignal(np.random.random((2, 3)))  # (|3, 2)
 
     def test_s2EELS2im2s(self):
-        pytest.importorskip("exspy")
         s = self.s.as_signal1D(0)
         s.set_signal_type("EELS")
         im = s.as_signal2D((1, 0))
@@ -100,11 +99,7 @@ class Test2d:
         s = im.as_signal1D(0)
         assert s.metadata.Signal.signal_type == "EELS"
         if s._lazy:
-            from exspy.signals import LazyEELSSpectrum
-
-            _class = LazyEELSSpectrum
+            _class = exspy.signals.LazyEELSSpectrum
         else:
-            from exspy.signals import EELSSpectrum
-
-            _class = EELSSpectrum
+            _class = exspy.signals.EELSSpectrum
         assert isinstance(s, _class)


### PR DESCRIPTION
### Description of the change
Some tests were still containing `importorskip` checks whether `exspy` is installed, which date to the point where they were still part of hyperspy.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [ ] ready for review.
