### PR TITLE
Add XrayDB database for xray lines

### DIFF
--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -580,6 +580,43 @@ background.
     Zr_Lb3
     background_order_6
 
+.. _eds_xray_databases-label:
+
+X-ray Line Databases
+^^^^^^^^^^^^^^^^^^^^^
+
+eXSpy supports two X-ray line energy databases to provide reference energies for X-ray lines:
+
+**XrayDB (default and recommended)**: An external database from the `XrayDB package <https://xraypy.github.io/XrayDB/>`_ 
+that provides high-precision X-ray line energies and related atomic data. XrayDB is maintained actively and 
+includes the most accurate and up-to-date values based on modern measurements and calculations.
+
+**Internal database**: A built-in database containing X-ray line energies derived from the 
+`NIST X-Ray Form Factor, Attenuation and Scattering Tables <https://www.nist.gov/pml/x-ray-form-factor-attenuation-and-scattering-tables>`_.
+
+The choice of database affects the reference energies used for X-ray line identification, peak fitting, 
+and energy calibration. XrayDB generally provides more accurate values and is therefore the default choice.
+
+You can specify which database to use when creating a model:
+
+.. code-block:: python
+
+    >>> # Use XrayDB (default, recommended)
+    >>> m = s.create_model(xray_line_source='xraydb')
+    
+    >>> # Use internal database
+    >>> m = s.create_model(xray_line_source='internal')
+
+For example, the Fe Kα line energy differs between the databases:
+
+- **XrayDB**: 6.40521 keV (more precise, modern value)
+- **Internal database**: 6.4039 keV (legacy value)
+
+.. NOTE::
+   XrayDB is now a strict requirement for eXSpy and provides superior accuracy for quantitative 
+   EDS analysis. The internal database is maintained for backward compatibility and specific 
+   use cases where legacy values are required.
+
 The width and the energies are fixed, while the heights of the sub-X-ray
 lines are linked to the main X-ray lines (alpha lines). The model can now be
 fitted:

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -591,7 +591,7 @@ eXSpy supports two X-ray line energy databases to provide reference energies for
 that provides high-precision X-ray line energies and related atomic data. XrayDB is maintained actively and 
 includes the most accurate and up-to-date values based on modern measurements and calculations.
 
-**Internal database**: A built-in database containing X-ray line energies derived from the 
+**Chantler2005 database**: A built-in database containing X-ray line energies derived from the 
 `NIST X-Ray Form Factor, Attenuation and Scattering Tables <https://www.nist.gov/pml/x-ray-form-factor-attenuation-and-scattering-tables>`_.
 
 The choice of database affects the reference energies used for X-ray line identification, peak fitting, 
@@ -604,17 +604,17 @@ You can specify which database to use when creating a model:
     >>> # Use XrayDB (default, recommended)
     >>> m = s.create_model(xray_line_source='xraydb')
     
-    >>> # Use internal database
-    >>> m = s.create_model(xray_line_source='internal')
+    >>> # Use Chantler2005 database
+    >>> m = s.create_model(xray_line_source='Chantler2005')
 
 For example, the Fe Kα line energy differs between the databases:
 
 - **XrayDB**: 6.40521 keV (more precise, modern value)
-- **Internal database**: 6.4039 keV (legacy value)
+- **Chantler2005 database**: 6.4039 keV (legacy value)
 
 .. NOTE::
    XrayDB is now a strict requirement for eXSpy and provides superior accuracy for quantitative 
-   EDS analysis. The internal database is maintained for backward compatibility and specific 
+   EDS analysis. The Chantler2005 database is maintained for backward compatibility and specific 
    use cases where legacy values are required.
 
 The width and the energies are fixed, while the heights of the sub-X-ray

--- a/exspy/_misc/eds/xraydb_utils.py
+++ b/exspy/_misc/eds/xraydb_utils.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2025 The eXSpy developers
+#
+# This file is part of eXSpy.
+#
+# eXSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# eXSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""
+Utilities for X-ray line data retrieval using XrayDB as primary source
+with fallback to internal database.
+"""
+
+import warnings
+from exspy._misc.eds.utils import _get_element_and_line, _get_energy_xray_line
+
+# Try to import XrayDB, set flag if available
+try:
+    import xraydb
+
+    XRAYDB_AVAILABLE = True
+except ImportError:
+    XRAYDB_AVAILABLE = False
+    xraydb = None
+
+
+def _xraydb_line_mapping(line):
+    """
+    Map line names from exspy format to xraydb format.
+
+    Parameters
+    ----------
+    line : str
+        X-ray line in exspy format (e.g., 'Ka', 'Kb', 'La', etc.)
+
+    Returns
+    -------
+    str
+        X-ray line in xraydb format (e.g., 'Ka1', 'Kb1', 'La1', etc.)
+        None if mapping not available
+    """
+    # XrayDB uses specific line names like Ka1, Ka2, etc.
+    # Map the main lines to their primary counterparts
+    line_map = {
+        "Ka": "Ka1",
+        "Kb": "Kb1",
+        "La": "La1",
+        "Lb": "Lb1",
+        "Lb1": "Lb1",
+        "Lb2": "Lb2",
+        "Lb3": "Lb3",
+        "Lb4": "Lb4",
+        "Lg1": "Lg1",
+        "Lg2": "Lg2",
+        "Lg3": "Lg3",
+        "Ll": "Ll",
+        "Ln": "Ln",
+        "Ma": "Ma1",
+        "Mb": "Mb",
+        "Mg": "Mg",
+        "Mz": "Mz",
+        # Add specific lines that might not need mapping
+        "Ka1": "Ka1",
+        "Ka2": "Ka2",
+        "Kb1": "Kb1",
+        "Kb2": "Kb2",
+        "Kb3": "Kb3",
+        "Kb5": "Kb5",
+        "La1": "La1",
+        "La2": "La2",
+        "Ma1": "Ma1",
+        "Ma2": "Ma2",
+        # Handle some special line notations
+        "M2N4": "M2N4",
+        "M3O4": "M3O4",
+        "M3O5": "M3O5",
+    }
+    return line_map.get(line, None)
+
+
+def get_xray_line_energy_xraydb(element, line):
+    """
+    Get X-ray line energy from XrayDB.
+
+    Parameters
+    ----------
+    element : str
+        Element symbol (e.g., 'Fe', 'Cu', etc.)
+    line : str
+        X-ray line designation (e.g., 'Ka', 'Kb', etc.)
+
+    Returns
+    -------
+    float or None
+        Energy in keV, None if not found
+    """
+    if not XRAYDB_AVAILABLE:
+        return None
+
+    try:
+        # Map line to XrayDB format
+        xraydb_line = _xraydb_line_mapping(line)
+        if xraydb_line is None:
+            return None
+
+        # Get energy from XrayDB (returns in eV, need to convert to keV)
+        energy_ev = xraydb.xray_line(element, xraydb_line).energy
+        return energy_ev / 1000.0  # Convert eV to keV
+
+    except (AttributeError, ValueError, KeyError):
+        # XrayDB might not have this line or element
+        return None
+
+
+def get_xray_line_energy_with_fallback(xray_line, source="xraydb"):
+    """
+    Get X-ray line energy with source preference and fallback.
+
+    Parameters
+    ----------
+    xray_line : str
+        X-ray line in format 'Element_Line' (e.g., 'Fe_Ka', 'Cu_Lb1')
+    source : {'xraydb', 'internal'}, default 'xraydb'
+        Primary source for X-ray line data:
+        - 'xraydb': Use XrayDB as primary source, fallback to internal
+        - 'internal': Use internal database only
+
+    Returns
+    -------
+    float
+        Energy in keV
+
+    Raises
+    ------
+    ValueError
+        If X-ray line not found in any source
+    """
+    element, line = _get_element_and_line(xray_line)
+
+    if source == "xraydb" and XRAYDB_AVAILABLE:
+        # Try XrayDB first
+        energy = get_xray_line_energy_xraydb(element, line)
+        if energy is not None:
+            return energy
+        else:
+            # Fallback to internal database
+            warnings.warn(
+                f"X-ray line {xray_line} not found in XrayDB, "
+                f"falling back to internal database.",
+                UserWarning,
+            )
+            return _get_energy_xray_line(xray_line)
+    elif source == "xraydb" and not XRAYDB_AVAILABLE:
+        # XrayDB requested but not available, warn and use internal
+        warnings.warn(
+            "XrayDB not available, falling back to internal database. "
+            "Install XrayDB with: pip install xraydb",
+            UserWarning,
+        )
+        return _get_energy_xray_line(xray_line)
+    else:
+        # Use internal database directly
+        return _get_energy_xray_line(xray_line)
+
+
+def get_available_xray_sources():
+    """
+    Get list of available X-ray line data sources.
+
+    Returns
+    -------
+    list of str
+        Available sources. Always includes 'internal',
+        includes 'xraydb' if XrayDB is available.
+    """
+    sources = ["internal"]
+    if XRAYDB_AVAILABLE:
+        sources.insert(0, "xraydb")  # Put xraydb first as preferred
+    return sources
+
+
+def validate_xray_line_source(source):
+    """
+    Validate X-ray line source parameter.
+
+    Parameters
+    ----------
+    source : str
+        The source to validate ('xraydb' or 'internal')
+
+    Raises
+    ------
+    ValueError
+        If source is not recognized
+    """
+    valid_sources = ["xraydb", "internal"]
+    if source not in valid_sources:
+        raise ValueError(
+            f"Invalid X-ray line source '{source}'. Valid options are: {valid_sources}"
+        )
+
+    # Just warn if XrayDB is not available but proceed anyway (will fallback)
+    if source == "xraydb" and not XRAYDB_AVAILABLE:
+        warnings.warn(
+            "XrayDB not available but 'xraydb' source was requested. "
+            "Install XrayDB with: pip install xraydb. "
+            "Will proceed with automatic fallback to internal database.",
+            UserWarning,
+        )

--- a/exspy/models/edssemmodel.py
+++ b/exspy/models/edssemmodel.py
@@ -33,13 +33,31 @@ class EDSSEMModel(EDSModel):
     auto_background : bool
         If True, adds automatically a polynomial order 6 to the model,
         using the edsmodel.add_polynomial_background method.
+    xray_line_source : str, default 'xraydb'
+        Source for X-ray line energy data. Options are:
+        - 'xraydb': Use XrayDB database (preferred, more accurate)
+        - 'internal': Use internal exspy database
+        If 'xraydb' is selected but XrayDB is not available, will
+        automatically fallback to 'internal' with a warning.
 
     Any extra arguments are passed to the Model constructor.
     """
 
     def __init__(
-        self, spectrum, auto_background=True, auto_add_lines=True, *args, **kwargs
+        self,
+        spectrum,
+        auto_background=True,
+        auto_add_lines=True,
+        xray_line_source="xraydb",
+        *args,
+        **kwargs,
     ):
         EDSModel.__init__(
-            self, spectrum, auto_background, auto_add_lines, *args, **kwargs
+            self,
+            spectrum,
+            auto_background,
+            auto_add_lines,
+            xray_line_source,
+            *args,
+            **kwargs,
         )

--- a/exspy/models/edssemmodel.py
+++ b/exspy/models/edssemmodel.py
@@ -36,9 +36,9 @@ class EDSSEMModel(EDSModel):
     xray_line_source : str, default 'xraydb'
         Source for X-ray line energy data. Options are:
         - 'xraydb': Use XrayDB database (preferred, more accurate)
-        - 'internal': Use internal exspy database
-        If 'xraydb' is selected but XrayDB is not available, will
-        automatically fallback to 'internal' with a warning.
+        - 'Chantler2005': Use Chantler2005 database
+        If 'xraydb' is selected but data is not available, will
+        automatically fallback to 'Chantler2005' with a warning.
 
     Any extra arguments are passed to the Model constructor.
     """

--- a/exspy/models/edstemmodel.py
+++ b/exspy/models/edstemmodel.py
@@ -36,9 +36,9 @@ class EDSTEMModel(EDSModel):
     xray_line_source : str, default 'xraydb'
         Source for X-ray line energy data. Options are:
         - 'xraydb': Use XrayDB database (preferred, more accurate)
-        - 'internal': Use internal exspy database
-        If 'xraydb' is selected but XrayDB is not available, will
-        automatically fallback to 'internal' with a warning.
+        - 'Chantler2005': Use Chantler2005 database
+        If 'xraydb' is selected but data is not available, will
+        automatically fallback to 'Chantler2005' with a warning.
 
     Any extra arguments are passed to the Model constructor.
     """

--- a/exspy/models/edstemmodel.py
+++ b/exspy/models/edstemmodel.py
@@ -33,13 +33,31 @@ class EDSTEMModel(EDSModel):
     auto_background : bool
         If True, adds automatically a polynomial order 6 to the model,
         using the edsmodel.add_polynomial_background method.
+    xray_line_source : str, default 'xraydb'
+        Source for X-ray line energy data. Options are:
+        - 'xraydb': Use XrayDB database (preferred, more accurate)
+        - 'internal': Use internal exspy database
+        If 'xraydb' is selected but XrayDB is not available, will
+        automatically fallback to 'internal' with a warning.
 
     Any extra arguments are passed to the Model constructor.
     """
 
     def __init__(
-        self, spectrum, auto_background=True, auto_add_lines=True, *args, **kwargs
+        self,
+        spectrum,
+        auto_background=True,
+        auto_add_lines=True,
+        xray_line_source="xraydb",
+        *args,
+        **kwargs,
     ):
         EDSModel.__init__(
-            self, spectrum, auto_background, auto_add_lines, *args, **kwargs
+            self,
+            spectrum,
+            auto_background,
+            auto_add_lines,
+            xray_line_source,
+            *args,
+            **kwargs,
         )

--- a/exspy/signals/eds.py
+++ b/exspy/signals/eds.py
@@ -54,7 +54,7 @@ class EDSSpectrum(Signal1D):
         self.axes_manager.signal_axes[0].is_binned = True
         self._xray_markers = {}
 
-    def _get_line_energy(self, Xray_line, FWHM_MnKa=None):
+    def _get_line_energy(self, Xray_line, FWHM_MnKa=None, xray_line_source="internal"):
         """
         Get the line energy and the energy resolution of a Xray line.
 
@@ -68,6 +68,10 @@ class EDSSpectrum(Signal1D):
             The energy resolution of the detector in eV
             if 'auto', used the one in
             'self.metadata.Acquisition_instrument.SEM.Detector.EDS.energy_resolution_MnKa'
+        xray_line_source : str, default 'internal'
+            Source for X-ray line energy data. Options are:
+            - 'xraydb': Use XrayDB database (preferred, more accurate)
+            - 'internal': Use internal exspy database
 
         Returns
         -------
@@ -90,7 +94,15 @@ class EDSSpectrum(Signal1D):
                     "`set_signal_type('EDS_SEM')` to convert to one of these"
                     "signal types."
                 )
-        line_energy = utils_eds._get_energy_xray_line(Xray_line)
+
+        # Get line energy using the selected source
+        if xray_line_source == "xraydb":
+            from exspy._misc.eds.xraydb_utils import get_xray_line_energy_with_fallback
+
+            line_energy = get_xray_line_energy_with_fallback(Xray_line, source="xraydb")
+        else:
+            line_energy = utils_eds._get_energy_xray_line(Xray_line)
+
         if units_name == "eV":
             line_energy *= 1000
             if FWHM_MnKa is not None:

--- a/exspy/signals/eds_sem.py
+++ b/exspy/signals/eds_sem.py
@@ -280,7 +280,14 @@ class EDSSEMSpectrum(EDSSpectrum):
         else:
             return False
 
-    def create_model(self, auto_background=True, auto_add_lines=True, *args, **kwargs):
+    def create_model(
+        self,
+        auto_background=True,
+        auto_add_lines=True,
+        xray_line_source="xraydb",
+        *args,
+        **kwargs,
+    ):
         """Create a model for the current SEM EDS data.
 
         Parameters
@@ -292,6 +299,12 @@ class EDSSEMSpectrum(EDSSpectrum):
             If True, automatically add Gaussians for all X-rays generated in
             the energy range by an element using the edsmodel.add_family_lines
             method.
+        xray_line_source : str, default 'xraydb'
+            Source for X-ray line energy data. Options are:
+            - 'xraydb': Use XrayDB database (preferred, more accurate)
+            - 'internal': Use internal exspy database
+            If 'xraydb' is selected but XrayDB is not available, will
+            automatically fallback to 'internal' with a warning.
         dictionary : {None, dict}, optional
             A dictionary to be used to recreate a model. Usually generated
             using :meth:`hyperspy.model.as_dictionary`
@@ -308,6 +321,7 @@ class EDSSEMSpectrum(EDSSpectrum):
             self,
             auto_background=auto_background,
             auto_add_lines=auto_add_lines,
+            xray_line_source=xray_line_source,
             *args,
             **kwargs,
         )

--- a/exspy/signals/eds_sem.py
+++ b/exspy/signals/eds_sem.py
@@ -302,9 +302,9 @@ class EDSSEMSpectrum(EDSSpectrum):
         xray_line_source : str, default 'xraydb'
             Source for X-ray line energy data. Options are:
             - 'xraydb': Use XrayDB database (preferred, more accurate)
-            - 'internal': Use internal exspy database
-            If 'xraydb' is selected but XrayDB is not available, will
-            automatically fallback to 'internal' with a warning.
+            - 'Chantler2005': Use Chantler2005 database
+            If 'xraydb' is selected but data is not available, will
+            automatically fallback to 'Chantler2005' with a warning.
         dictionary : {None, dict}, optional
             A dictionary to be used to recreate a model. Usually generated
             using :meth:`hyperspy.model.as_dictionary`

--- a/exspy/signals/eds_tem.py
+++ b/exspy/signals/eds_tem.py
@@ -762,7 +762,14 @@ class EDSTEMSpectrum(EDSSpectrum):
         )
         self.learning_results.loadings = np.nan_to_num(self.learning_results.loadings)
 
-    def create_model(self, auto_background=True, auto_add_lines=True, *args, **kwargs):
+    def create_model(
+        self,
+        auto_background=True,
+        auto_add_lines=True,
+        xray_line_source="xraydb",
+        *args,
+        **kwargs,
+    ):
         """Create a model for the current TEM EDS data.
 
         Parameters
@@ -774,6 +781,12 @@ class EDSTEMSpectrum(EDSSpectrum):
             If True, automatically add Gaussians for all X-rays generated in
             the energy range by an element using the edsmodel.add_family_lines
             method.
+        xray_line_source : str, default 'xraydb'
+            Source for X-ray line energy data. Options are:
+            - 'xraydb': Use XrayDB database (preferred, more accurate)
+            - 'internal': Use internal exspy database
+            If 'xraydb' is selected but XrayDB is not available, will
+            automatically fallback to 'internal' with a warning.
         dictionary : {None, dict}, optional
             A dictionary to be used to recreate a model. Usually generated
             using :meth:`hyperspy.model.as_dictionary`
@@ -789,6 +802,7 @@ class EDSTEMSpectrum(EDSSpectrum):
             self,
             auto_background=auto_background,
             auto_add_lines=auto_add_lines,
+            xray_line_source=xray_line_source,
             *args,
             **kwargs,
         )

--- a/exspy/tests/models/test_edsmodel.py
+++ b/exspy/tests/models/test_edsmodel.py
@@ -26,13 +26,6 @@ import exspy
 from exspy._misc.eds import utils as utils_eds
 from exspy._misc.elements import elements as elements_db
 
-try:
-    import importlib.util
-
-    XRAYDB_AVAILABLE = importlib.util.find_spec("xraydb") is not None
-except ImportError:
-    XRAYDB_AVAILABLE = False
-
 
 # Create this outside the test class to
 # reduce computation in test suite by ~10seconds
@@ -167,15 +160,7 @@ class TestlineFit:
 
     @pytest.mark.parametrize(
         "xray_line_source",
-        [
-            "internal",
-            pytest.param(
-                "xraydb",
-                marks=pytest.mark.skipif(
-                    not XRAYDB_AVAILABLE, reason="xraydb not available"
-                ),
-            ),
-        ],
+        ["Chantler2005", "xraydb"],
     )
     def test_calibrate_xray_energy(self, xray_line_source):
         s = self.s
@@ -185,7 +170,7 @@ class TestlineFit:
 
         m.calibrate_xray_lines(calibrate="energy", xray_lines=["Fe_Ka"], bound=100)
 
-        if xray_line_source == "internal":
+        if xray_line_source == "Chantler2005":
             expected_energy = elements_db["Fe"]["Atomic_properties"]["Xray_lines"][
                 "Ka"
             ]["energy (keV)"]
@@ -229,15 +214,7 @@ class TestlineFit:
 
     @pytest.mark.parametrize(
         "xray_line_source",
-        [
-            "internal",
-            pytest.param(
-                "xraydb",
-                marks=pytest.mark.skipif(
-                    not XRAYDB_AVAILABLE, reason="xraydb not available"
-                ),
-            ),
-        ],
+        ["Chantler2005", "xraydb"],
     )
     def test_calibrate_xray_width(self, xray_line_source):
         s = self.s

--- a/exspy/tests/models/test_linear_model.py
+++ b/exspy/tests/models/test_linear_model.py
@@ -96,7 +96,7 @@ class TestTwinnedComponents:
     def test_fit_background(self):
         m2 = self.m2
         m2.fit_background(optimizer="lstsq")
-        np.testing.assert_allclose(m2[0].a0.value, 11045209.18)
+        np.testing.assert_allclose(m2[0].a0.value, 10694878.075087)
 
     def test_fit_background_reset_signal_range(self):
         m2 = self.m2

--- a/exspy/tests/models/test_xraydb_integration.py
+++ b/exspy/tests/models/test_xraydb_integration.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2025 The eXSpy developers
+#
+# This file is part of eXSpy.
+#
+# eXSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# eXSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""Test suite for XrayDB integration in exspy."""
+
+import pytest
+from hyperspy.decorators import lazifyTestClass
+
+import exspy
+from exspy._misc.eds import utils as utils_eds
+from exspy._misc.eds.xraydb_utils import (
+    get_xray_line_energy_with_fallback,
+    validate_xray_line_source,
+)
+
+# Skip all tests if xraydb is not available
+pytest.importorskip("xraydb")
+
+
+class TestXrayDBIntegration:
+    """Test XrayDB integration functionality."""
+
+    def test_parameter_validation(self):
+        """Test that parameter validation works correctly."""
+        # Valid parameters should pass
+        validate_xray_line_source("xraydb")
+        validate_xray_line_source("internal")
+
+        # Invalid parameters should raise ValueError
+        with pytest.raises(ValueError):
+            validate_xray_line_source("invalid")
+
+    def test_energy_retrieval_with_fallback(self):
+        """Test X-ray line energy retrieval with fallback mechanism."""
+        test_lines = ["Al_Ka", "Fe_Ka", "Cu_Ka"]
+
+        for xray_line in test_lines:
+            # Both sources should return valid energies
+            internal_energy = get_xray_line_energy_with_fallback(
+                xray_line, source="internal"
+            )
+            xraydb_energy = get_xray_line_energy_with_fallback(
+                xray_line, source="xraydb"
+            )
+
+            assert internal_energy > 0, (
+                f"Internal energy for {xray_line} should be positive"
+            )
+            assert xraydb_energy > 0, (
+                f"XrayDB energy for {xray_line} should be positive"
+            )
+
+            # Energies should be close but may differ slightly
+            diff_ev = abs(xraydb_energy - internal_energy) * 1000
+            assert diff_ev < 10, (
+                f"Energy difference for {xray_line} too large: {diff_ev} eV"
+            )
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_model_creation_with_sources(self, source):
+        """Test model creation with different X-ray line sources."""
+        s_sem = exspy.data.EDS_SEM_TM002()
+        s_tem = exspy.data.EDS_TEM_FePt_nanoparticles()
+
+        # Should be able to create models with both sources
+        m_sem = s_sem.create_model(xray_line_source=source, auto_add_lines=False)
+        m_tem = s_tem.create_model(xray_line_source=source, auto_add_lines=False)
+
+        assert len(m_sem) > 0, "SEM model should have background component"
+        assert len(m_tem) > 0, "TEM model should have background component"
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_family_lines_addition(self, source):
+        """Test adding family lines with different sources."""
+        s = exspy.data.EDS_SEM_TM002()
+        m = s.create_model(xray_line_source=source, auto_add_lines=False)
+
+        # Add specific lines
+        m.add_family_lines(["Al_Ka", "Cu_Ka"])
+
+        # Check that lines were added
+        assert "Al_Ka" in [comp.name for comp in m]
+        assert "Cu_Ka" in [comp.name for comp in m]
+
+        # Check that energies are reasonable
+        al_ka_energy = m["Al_Ka"].centre.value
+        cu_ka_energy = m["Cu_Ka"].centre.value
+
+        assert 1.4 < al_ka_energy < 1.5, (
+            f"Al_Ka energy should be ~1.49 keV, got {al_ka_energy}"
+        )
+        assert 8.0 < cu_ka_energy < 8.1, (
+            f"Cu_Ka energy should be ~8.05 keV, got {cu_ka_energy}"
+        )
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_auto_add_lines(self, source):
+        """Test automatic line addition from metadata."""
+        s = exspy.data.EDS_SEM_TM002()
+
+        # Create model with auto_add_lines=True
+        m = s.create_model(xray_line_source=source, auto_add_lines=True)
+
+        # Should have added lines for elements in metadata
+        component_names = [comp.name for comp in m]
+
+        # Check that some expected lines are present based on metadata elements
+        assert any("Al_Ka" in name for name in component_names), (
+            "Al_Ka line should be added"
+        )
+        assert any("Cu_Ka" in name for name in component_names), (
+            "Cu_Ka line should be added"
+        )
+        assert any("Mn_Ka" in name for name in component_names), (
+            "Mn_Ka line should be added"
+        )
+
+
+class TestDatabaseSourcesCalibration:
+    """Test X-ray line energy calibration with different database sources."""
+
+    def test_calibration_with_both_sources(self):
+        """Test energy calibration with both database sources."""
+        # Create a test spectrum
+        s = utils_eds.xray_lines_model(
+            elements=["Fe"],
+            beam_energy=200,
+            weight_percents=[100],
+            energy_axis={
+                "units": "keV",
+                "size": 400,
+                "scale": 0.01,
+                "name": "E",
+                "offset": 5.0,
+            },
+        )
+
+        for source in ["internal", "xraydb"]:
+            # Create model with specific database source
+            m = s.create_model(xray_line_source=source)
+            m.fit()
+
+            # Get reference energy
+            reference_energy, _ = s._get_line_energy(
+                "Fe_Ka", FWHM_MnKa="auto", xray_line_source=source
+            )
+
+            # Deliberately set wrong energy
+            m["Fe_Ka"].centre.value = 6.39
+            assert m["Fe_Ka"].centre.value == 6.39, (
+                "Energy should be set to wrong value"
+            )
+
+            # Calibrate energy
+            m.calibrate_xray_lines(calibrate="energy", xray_lines=["Fe_Ka"])
+            calibrated_energy = m["Fe_Ka"].centre.value
+
+            # Check that calibration worked
+            assert abs(calibrated_energy - reference_energy) < 1e-6, (
+                f"Calibrated energy should match reference for {source} source"
+            )
+            assert not m["Fe_Ka"].centre.free, (
+                f"Line should be fixed after calibration with {source}"
+            )
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_calibration_accuracy(self, source):
+        """Test that calibration restores correct energy values."""
+        s = utils_eds.xray_lines_model(
+            elements=["Al", "Fe"],
+            beam_energy=200,
+            weight_percents=[50, 50],
+            energy_axis={
+                "units": "keV",
+                "size": 800,
+                "scale": 0.01,
+                "name": "E",
+                "offset": 1.0,
+            },
+        )
+
+        m = s.create_model(xray_line_source=source)
+        m.fit()
+
+        # Store reference energies
+        al_ref, _ = s._get_line_energy(
+            "Al_Ka", FWHM_MnKa="auto", xray_line_source=source
+        )
+        fe_ref, _ = s._get_line_energy(
+            "Fe_Ka", FWHM_MnKa="auto", xray_line_source=source
+        )
+
+        # Introduce errors
+        m["Al_Ka"].centre.value = 1.4  # Wrong value
+        m["Fe_Ka"].centre.value = 6.0  # Wrong value
+
+        # Calibrate
+        m.calibrate_xray_lines(calibrate="energy", xray_lines=["Al_Ka", "Fe_Ka"])
+
+        # Check accuracy
+        assert abs(m["Al_Ka"].centre.value - al_ref) < 1e-6, "Al_Ka calibration failed"
+        assert abs(m["Fe_Ka"].centre.value - fe_ref) < 1e-6, "Fe_Ka calibration failed"
+
+
+@lazifyTestClass
+class TestXrayDBWithLazySignals:
+    """Test XrayDB integration with lazy signals."""
+
+    def setup_method(self, method):
+        self.s_sem = exspy.data.EDS_SEM_TM002()
+        self.s_tem = exspy.data.EDS_TEM_FePt_nanoparticles()
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_lazy_model_creation(self, source):
+        """Test that lazy signals work with XrayDB integration."""
+        # Create models with both sources
+        m_sem = self.s_sem.create_model(xray_line_source=source, auto_add_lines=False)
+        m_tem = self.s_tem.create_model(xray_line_source=source, auto_add_lines=False)
+
+        # Should work regardless of lazy or not
+        assert len(m_sem) >= 1, "SEM model should have at least background"
+        assert len(m_tem) >= 1, "TEM model should have at least background"
+
+    @pytest.mark.parametrize("source", ["internal", "xraydb"])
+    def test_lazy_family_lines(self, source):
+        """Test adding family lines to lazy signals."""
+        m = self.s_sem.create_model(xray_line_source=source, auto_add_lines=False)
+
+        # Add lines
+        m.add_family_lines(["Al_Ka"])
+
+        # Should work with lazy signals
+        assert "Al_Ka" in [comp.name for comp in m]
+        assert hasattr(m["Al_Ka"], "centre")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "requests",
   "scipy",
   "traits",
+  "xraydb",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
### Description of the change

The Xray lines information in EXSpy is from the following paper:

Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova, S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and Scattering Tables (version 2.1).  https://dx.doi.org/10.18434/T4HS32

This PR implements a new source, more accurate and comprehensive source, the [XrayDB](https://xraypy.github.io/XrayDB/) and makes it the default. A new `xray_line_source` enables selecting the database in relevant functions.

```python
>>> # Use XrayDB (default, recommended)
>>> m = s.create_model()

>>> # Use Chantler2005 database
>>> m = s.create_model(xray_line_source='Chantler2005')
```

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [x] added tests,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.



