### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,32 @@
+name: Integration tests
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'pre-commit-ci-update-config'
+  workflow_dispatch:
+
+jobs:
+  integration_test:
+    # if: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') || github.event_name == 'workflow_dispatch' }}
+    name: hs_${{ matrix.HYPERSPY_VERSION }}-rs_${{ matrix.ROSETTASCIIO_VERSION }}-ext_${{ matrix.EXTENSION_VERSION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        EXTENSION_VERSION: ['release', 'dev']
+        ROSETTASCIIO_VERSION: ['release', 'dev']
+        HYPERSPY_VERSION: ['release', 'RnM', 'RnP']
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/integration_tests.yml@main
+    with:
+      # atomap depends on exspy
+      EXTENSIONS: 'atomap hyperspy-gui-ipywidgets hyperspy-gui-traitsui'
+      EXTENSION_VERSION: ${{ matrix.EXTENSION_VERSION }}
+      HYPERSPY_VERSION: ${{ matrix.HYPERSPY_VERSION }}
+      ROSETTASCIIO_VERSION: ${{ matrix.ROSETTASCIIO_VERSION }}
+      PIP_EXTRAS: '[all,tests]'
+      USE_CONDA: false

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   integration_test:
-    # if: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') || github.event_name == 'workflow_dispatch' }}
     name: hs_${{ matrix.HYPERSPY_VERSION }}-rs_${{ matrix.ROSETTASCIIO_VERSION }}-ext_${{ matrix.EXTENSION_VERSION }}
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -88,6 +88,18 @@ Please refer to the `HyperSpy development guide
 <https://hyperspy.org/hyperspy-doc/current/dev_guide/testing.html>`_ for further
 information on tests.
 
+Integration tests
+=================
+
+The `Integration test <https://github.com/hyperspy/hyperspy/actions/workflows/integration_tests.yml>`__
+workflow runs the test suite of other libraries in the HyperSpy eco-system using the current development
+branch of exspy. It can be used to check if changes in the eXSpy libraries break these other libraries.
+It can run from pull requests (PR) to the `eXSpy <https://github.com/hyperspy/exspy>`_ repository
+when the label ``run-integration-tests`` is added to a PR.
+
+This workflow uses the `integration_tests.yml <https://github.com/hyperspy/.github/blob/main/.github/workflows/integration_tests.yml>`_
+reusable workflow from the https://github.com/hyperspy/.github repository.
+
 Releasing a new version
 =======================
 

--- a/upcoming_changes/134.maintenance.rst
+++ b/upcoming_changes/134.maintenance.rst
@@ -1,0 +1,1 @@
+Add integration tests to run the test suites of software packages in the HyperSpy ecosystem.


### PR DESCRIPTION
The failure of build testing against hyperpy next minor branch is expected until the next rosettasciio release.

### Progress of the PR
- [x] Add integration tests using reusable workflow from https://github.com/hyperspy/.github/blob/main/.github/workflows/integration_tests.yml,
- [n/a] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.


