### PR TITLE
Intensities threshold

### DIFF
--- a/exspy/_docstrings/eds.py
+++ b/exspy/_docstrings/eds.py
@@ -33,6 +33,12 @@ DOSE_DOC = """beam_current : float or "auto"
             area can be approximated to the pixel area of the spectrum image.
             Only for the ``"cross_section"`` method."""
 
+INTENSITIES_THRESHOLD_DOC = """intensities_threshold : float, optional
+        Threshold value used to set individual intensity values to zero when they
+        fall below this threshold. This helps filter out noise and very low
+        intensity peaks. If <= 0, no individual intensity thresholding is applied.
+        Default is 1.0."""
+
 
 INTENSITIES_SUM_THRESHOLD_DOC = """intensities_sum_threshold : int, float or None, optional
         Threshold value used to set output values to zero in areas with very low

--- a/exspy/_docstrings/eds.py
+++ b/exspy/_docstrings/eds.py
@@ -34,6 +34,14 @@ DOSE_DOC = """beam_current : float or "auto"
             Only for the ``"cross_section"`` method."""
 
 
+INTENSITIES_SUM_THRESHOLD_DOC = """intensities_sum_threshold : int, float or None, optional
+        Threshold value used to set output values to zero in areas with very low
+        X-ray intensities, such as vacuum areas. If the sum of the
+        intensities falls below this threshold, the output is set to zero.
+        If None, the length of the intensities list is used as the threshold.
+        Default is None."""
+
+
 WEIGHT_THRESHOLD_PARAMETER = """weight_threshold : float
         Define the threshold of the weight below which the lines are
         ignored. Must be between 0 and 1. Default is 0.1."""

--- a/exspy/signals/eds_tem.py
+++ b/exspy/signals/eds_tem.py
@@ -36,7 +36,7 @@ from hyperspy.axes import DataAxis
 
 from .eds import EDSSpectrum, LazyEDSSpectrum
 from exspy._defaults_parser import preferences
-from exspy._docstrings.eds import DOSE_DOC
+from exspy._docstrings.eds import DOSE_DOC, INTENSITIES_THRESHOLD_DOC
 from exspy._misc import material
 from exspy._misc.eds import utils as utils_eds
 from exspy._misc.elements import elements as elements_db
@@ -315,6 +315,7 @@ class EDSTEMSpectrum(EDSSpectrum):
         live_time="auto",
         probe_area="auto",
         max_iterations=30,
+        intensities_threshold=2.0,
         show_progressbar=None,
         **kwargs,
     ):
@@ -365,6 +366,7 @@ class EDSTEMSpectrum(EDSSpectrum):
         plot_result : bool
             If True, plot the calculated composition. If the current
             object is a single spectrum it prints the result instead.
+        %s
         max_iterations : int
             An upper limit to the number of calculations for absorption correction.
         %s
@@ -447,7 +449,7 @@ class EDSTEMSpectrum(EDSSpectrum):
         comp_old = np.zeros_like(int_stack.data)
 
         # kwargs to pass to the quantification function
-        qkwargs = {}
+        qkwargs = {"intensities_threshold": intensities_threshold}
         if method == "CL":
             quantification_method = utils_eds.quantification_cliff_lorimer
             qkwargs["mask"] = navigation_mask
@@ -583,7 +585,7 @@ class EDSTEMSpectrum(EDSSpectrum):
                 '"CL", "zeta" or "cross_section"'
             )
 
-    quantification.__doc__ %= DOSE_DOC
+    quantification.__doc__ %= (DOSE_DOC, INTENSITIES_THRESHOLD_DOC)
 
     def vacuum_mask(self, threshold=1.0, closing=True, opening=False):
         """

--- a/exspy/tests/signals/test_eds_tem.py
+++ b/exspy/tests/signals/test_eds_tem.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import warnings
 
 import numpy as np
 import pytest
@@ -485,11 +484,11 @@ class Test_quantification:
                 [0.5, 0.0, 0.0],
             ]
         ).T
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="divide by zero encountered", category=RuntimeWarning
-            )
-            quant = utils_eds.quantification_cliff_lorimer(intens, [1, 1, 3]).T
+
+        # Specify intensities_sum_threshold not to set output values to zero
+        quant = utils_eds.quantification_cliff_lorimer(
+            intens, [1, 1, 3], intensities_sum_threshold=0.1
+        ).T
         np.testing.assert_allclose(
             quant,
             np.array(
@@ -502,6 +501,10 @@ class Test_quantification:
                 ]
             ),
         )
+
+        # with default value of intensities_sum_threshold
+        quant = utils_eds.quantification_cliff_lorimer(intens, [1, 1, 3]).T
+        np.testing.assert_allclose(quant, np.zeros_like(quant))
 
     def test_edx_cross_section_to_zeta(self):
         cs = [3, 6]

--- a/exspy/tests/signals/test_eds_tem.py
+++ b/exspy/tests/signals/test_eds_tem.py
@@ -487,7 +487,7 @@ class Test_quantification:
 
         # Specify intensities_sum_threshold not to set output values to zero
         quant = utils_eds.quantification_cliff_lorimer(
-            intens, [1, 1, 3], intensities_sum_threshold=0.1
+            intens, [1, 1, 3], intensities_threshold=0, intensities_sum_threshold=0
         ).T
         np.testing.assert_allclose(
             quant,
@@ -505,6 +505,89 @@ class Test_quantification:
         # with default value of intensities_sum_threshold
         quant = utils_eds.quantification_cliff_lorimer(intens, [1, 1, 3]).T
         np.testing.assert_allclose(quant, np.zeros_like(quant))
+
+    def test_quantification_cliff_lorimer_with_intensities_threshold(self):
+        # Test the new intensities_threshold parameter
+        # Setup test data: 3 elements, 5 pixels (first axis = elements)
+        # Include some values that will be filtered by threshold=1.0
+        # Use moderate values in range 1-30 to test threshold behavior
+        intens = np.array(
+            [
+                [5.0, 2.0, 1.5, 8.0, 25.0],  # First element intensities
+                [4.0, 0.8, 2.5, 6.0, 15.0],  # Second element intensities
+                [8.0, 3.0, 4.0, 7.0, 20.0],  # Third element intensities
+            ]
+        )  # Shape: (3 elements, 5 pixels)
+        # Sums per pixel: [17.0, 5.8, 8.0, 21.0, 60.0] - reasonable intensity values
+
+        # Test without threshold (baseline) - set to 0 to disable
+        quant_no_threshold = utils_eds.quantification_cliff_lorimer(
+            intens, [1, 1, 3], intensities_threshold=0
+        )
+
+        # Test with default threshold (1.0) - should be applied automatically
+        quant_default_threshold = utils_eds.quantification_cliff_lorimer(
+            intens, [1, 1, 3]
+        )
+
+        # Apply explicit intensities_threshold=1.0 (same as default)
+        # This should set values < 1.0 to zero: 0.8, 0.5, 0.3, 0.9 -> 0.0
+        quant_with_threshold = utils_eds.quantification_cliff_lorimer(
+            intens, [1, 1, 3], intensities_threshold=1.0
+        )
+
+        # Default and explicit 1.0 should be the same
+        np.testing.assert_allclose(
+            quant_default_threshold, quant_with_threshold, rtol=1e-10
+        )
+
+        # Check that results are different when threshold is applied vs disabled
+        # With threshold=1.0, values [0.8] should become 0.0
+        # This will change the quantification results
+        assert not np.array_equal(quant_no_threshold, quant_with_threshold)
+
+        # The quantification should handle the modified intensities
+        assert quant_with_threshold.shape == (3, 5)  # 3 elements, 5 pixels
+
+        # Test with both thresholds
+        quant_both = utils_eds.quantification_cliff_lorimer(
+            intens,
+            [1, 1, 3],
+            intensities_threshold=2.0,  # Filter values < 2.0: 1.5, 0.8 -> 0.0
+            intensities_sum_threshold=10.0,  # Only keep pixels where sum >= 10.0
+        )
+
+        # Check that the sum threshold is applied correctly
+        # Sum of original intensities per pixel: [17.0, 5.8, 8.0, 21.0, 60.0]
+        # With sum_threshold=10.0, only pixels 0, 3, and 4 should have non-zero results
+        assert np.all(quant_both[:, 1] == 0)  # Pixel 1: sum=5.8 < 10.0
+        assert np.all(quant_both[:, 2] == 0)  # Pixel 2: sum=8.0 < 10.0
+
+        # Test that intensities_threshold=0 (disables threshold) works
+        quant_zero_threshold = utils_eds.quantification_cliff_lorimer(
+            intens, [1, 1, 3], intensities_threshold=0, intensities_sum_threshold=0
+        )
+
+        # Should be same as the no threshold case since they're the same call
+        np.testing.assert_allclose(quant_zero_threshold, quant_no_threshold, rtol=1e-10)
+
+        # Test specific behavior: verify that low intensities are actually being filtered
+        # Create a simple case where the difference is obvious
+        simple_intens = np.array(
+            [[10.0, 2.0], [8.0, 1.5], [12.0, 0.8]]
+        )  # 3 elements, 2 pixels
+
+        simple_no_threshold = utils_eds.quantification_cliff_lorimer(
+            simple_intens, [1, 1, 1], intensities_threshold=0
+        )
+        simple_with_threshold = utils_eds.quantification_cliff_lorimer(
+            simple_intens,
+            [1, 1, 1],
+            intensities_threshold=1.0,  # Should filter 0.8
+        )
+
+        # These should definitely be different
+        assert not np.array_equal(simple_no_threshold, simple_with_threshold)
 
     def test_edx_cross_section_to_zeta(self):
         cs = [3, 6]


### PR DESCRIPTION
Add threshold to set intensities to zero during and/or after quantification. This is useful to set quantification results to zero when there is very small intensities.

### Progress of the PR
- [x] Add `intensities_threshold` to set intensities values to 0 when it is below the threshold,
- [x] add `intensities_sum_threshold` to set quantified values to set when it is below the threshold,
- [x] docstring updated (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] added tests,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [ ] ready for review.


