### PR TITLE
Ignore dependabot and pre-commit branches on push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'pre-commit-ci-update-config'
+  pull_request:
 
 jobs:
   run_test_site:


### PR DESCRIPTION
Same as in https://github.com/hyperspy/hyperspy/pull/3544: avoid running duplicate tests workflows as for example in #137.


