### PR TITLE
Add convenience functionalities: `get_xray_lines`, `print_lines` and `print_lines_near_energy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 doc/_build/*
 doc/auto_examples/*
 doc/sg_execution_times.rst
+doc/backreferences/*
 build/*
 dist/*
 *egg-info*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -146,6 +146,11 @@ toc_object_entries_show_parents = "hide"
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to your example scripts
     "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
+    # directory where function/class granular galleries are stored
+    "backreferences_dir": "backreferences",
+    # Modules for which function/class level galleries are created. In
+    # this case hyperspy in a tuple of strings.
+    "doc_module": ("exspy",),
     "filename_pattern": ".py",  # pattern to define which will be executed
     "ignore_pattern": "_sgskip.py",  # pattern to define which will not be executed
 }

--- a/doc/reference/utils.eds.rst
+++ b/doc/reference/utils.eds.rst
@@ -7,7 +7,10 @@
 .. autosummary::
    cross_section_to_zeta
    electron_range
+   get_xray_lines
    get_xray_lines_near_energy
+   print_lines
+   print_lines_near_energy
    take_off_angle
    xray_range
    zeta_to_cross_section

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -357,6 +357,9 @@ database:
 The lines are returned in order of distance from the specified energy, and can
 be limited by additional, optional arguments.
 
+.. minigallery:: ../examples/EDS/find_EDS_lines*
+
+
 .. _eds_plot-label:
 
 Plotting

--- a/examples/EDS/README.rst
+++ b/examples/EDS/README.rst
@@ -1,0 +1,4 @@
+Energy Dispersive X-ray Spectroscopy (EDS)
+==========================================
+
+Below is a gallery of examples on energy dispersive X-ray spectroscopy (EDS).

--- a/examples/EDS/find_EDS_lines.py
+++ b/examples/EDS/find_EDS_lines.py
@@ -1,0 +1,40 @@
+"""
+Find EDS lines
+==============
+
+This example demonstrates how to find EDS lines.
+
+"""
+
+import exspy
+
+# %%
+# Show the X-ray lines near 6.4 keV:
+exspy.utils.eds.print_lines_near_energy(energy=6.4)
+
+# %%
+# Show the main (high weight) X-ray lines near 6.4 keV:
+exspy.utils.eds.print_lines_near_energy(energy=6.4, weight_threshold=0.5)
+
+
+# %%
+# Show all X-ray lines for a given element
+exspy.utils.eds.print_lines(elements=["Fe"])
+
+
+# %%
+# Show all X-ray lines for multiple elements
+exspy.utils.eds.print_lines(elements=["Fe", "Pt"])
+
+# %%
+# Show all X-ray lines from a signal of the elements defined in the metadata
+s = exspy.data.EDS_TEM_FePt_nanoparticles()
+s.plot(xray_lines=True)
+
+s.print_lines()
+
+# %%
+# Display the X-ray lines close to 8 keV, which corresponds to the Cu Kα line
+# coming from the TEM grid
+
+s.print_lines_near_energy(8.0)

--- a/exspy/_docstrings/eds.py
+++ b/exspy/_docstrings/eds.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-"""Common docstring snippets for model."""
+"""Common docstring snippets for EDS functionality."""
 
 DOSE_DOC = """beam_current : float or "auto"
             Probe current in nA.
@@ -32,3 +32,34 @@ DOSE_DOC = """beam_current : float or "auto"
             assuming that the probe is oversampling such that the illumination
             area can be approximated to the pixel area of the spectrum image.
             Only for the ``"cross_section"`` method."""
+
+
+WEIGHT_THRESHOLD_PARAMETER = """weight_threshold : float
+        Define the threshold of the weight below which the lines are
+        ignored. Must be between 0 and 1. Default is 0.1."""
+
+
+ENERGY_RANGE_PARAMETER = """energy_range : list or tuple of length 2
+        Define the start and the end of the X-ray energy range to consider.
+        X-ray energies outside the range will be ignored. If ``None``,
+        all X-ray energies are considered. Default is None."""
+
+
+WIDTH_PARAMETER = """width : float
+        Window width in keV around energy in which to find nearby energies,
+        i.e. a value of 0.1 keV (the default) means to search +/- 0.05 keV."""
+
+
+ONLY_LINES_PARAMETER = """only_lines : list of str, optional
+        Define the lines to be considered (eg. ('a','Kb')).
+        If None, all lines are included. Default is None."""
+
+
+SORTING_PARAMETER = """sorting : str
+        Define the sorting of the table, either ``"elements"`` or ``"energy"``.
+        Default is ``"elements"``."""
+
+
+FLOAT_FORMAT_PARAMETER = """float_format : str
+        The formatting of the float in the table passed to
+        :class:`prettytable.PrettyTable`. Default is ".2"."""

--- a/exspy/misc/eds/utils.py
+++ b/exspy/misc/eds/utils.py
@@ -5,7 +5,10 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 from exspy._misc.eds.utils import (
     cross_section_to_zeta,
     electron_range,
+    get_xray_lines,
     get_xray_lines_near_energy,
+    print_lines,
+    print_lines_near_energy,
     take_off_angle,
     xray_range,
     zeta_to_cross_section,
@@ -21,7 +24,10 @@ warnings.warn(
 __all__ = [
     "cross_section_to_zeta",
     "electron_range",
+    "get_xray_lines",
     "get_xray_lines_near_energy",
+    "print_lines",
+    "print_lines_near_energy",
     "take_off_angle",
     "xray_range",
     "zeta_to_cross_section",

--- a/exspy/signals/eds.py
+++ b/exspy/signals/eds.py
@@ -16,24 +16,32 @@
 # You should have received a copy of the GNU General Public License
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from collections.abc import Iterable
 import itertools
 import logging
-
-import numpy as np
 import warnings
-from collections.abc import Iterable
+
 from matplotlib import pyplot as plt
+import numpy as np
 
 import hyperspy.api as hs
 from hyperspy import utils
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.signal1d import Signal1D, LazySignal1D
-from exspy._misc.elements import elements as elements_db
-from exspy._misc.eds import utils as utils_eds
 from hyperspy.misc.utils import isiterable
 from hyperspy.docstrings.plot import BASE_PLOT_DOCSTRING_PARAMETERS, PLOT1D_DOCSTRING
 from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
 
+from exspy._docstrings.eds import (
+    ENERGY_RANGE_PARAMETER,
+    FLOAT_FORMAT_PARAMETER,
+    ONLY_LINES_PARAMETER,
+    SORTING_PARAMETER,
+    WEIGHT_THRESHOLD_PARAMETER,
+    WIDTH_PARAMETER,
+)
+from exspy._misc.elements import elements as elements_db
+from exspy._misc.eds import utils as utils_eds
 
 _logger = logging.getLogger(__name__)
 
@@ -1174,6 +1182,138 @@ class EDSSpectrum(Signal1D):
 
         if render_figure:
             self._render_figure(plot=["signal_plot"])
+
+    def print_lines_near_energy(
+        self,
+        energy,
+        width=0.1,
+        only_lines=None,
+        weight_threshold=0.1,
+        sorting="energy",
+        float_format=".2",
+    ):
+        """
+        Display a table of X-ray lines close to a given energy.
+
+        Parameters
+        ----------
+        energy : float
+            The energy to search around, in keV.
+        %s
+        %s
+        %s
+        %s
+        %s
+
+        Examples
+        --------
+        >>> import exspy
+        >>> s = exspy.data.EDS_TEM_FePt_nanoparticles()
+        >>> s.print_lines_near_energy(energy=8)
+        +---------+------+--------------+--------+------------+
+        | Element | Line | Energy (keV) | Weight | Intensity  |
+        +---------+------+--------------+--------+------------+
+        |    Ho   | Lb2  |     7.91     |  0.24  | ##         |
+        |    Er   | Lb3  |     7.94     |  0.13  | #          |
+        |    Cu   |  Ka  |     8.05     |  1.00  | ########## |
+        +---------+------+--------------+--------+------------+
+
+        See also
+        --------
+        print_lines, exspy.utils.eds.get_xray_lines,
+        exspy.utils.eds.get_xray_lines_near_energy
+        """
+        utils_eds.print_lines_near_energy(
+            energy=energy,
+            width=width,
+            weight_threshold=weight_threshold,
+            sorting=sorting,
+            float_format=float_format,
+        )
+
+    print_lines_near_energy.__doc__ %= (
+        WIDTH_PARAMETER.replace("    ", "        "),
+        WEIGHT_THRESHOLD_PARAMETER.replace("    ", "        "),
+        ONLY_LINES_PARAMETER.replace("    ", "        "),
+        SORTING_PARAMETER.replace("    ", "        "),
+        FLOAT_FORMAT_PARAMETER.replace("    ", "        "),
+    )
+
+    def print_lines(
+        self,
+        elements=None,
+        weight_threshold=0.1,
+        energy_range=None,
+        only_lines=None,
+        sorting="elements",
+        float_format=".2",
+    ):
+        """
+        Display a table of X-ray lines for given elements.
+
+        Parameters
+        ----------
+        elements : list, tuple or None
+            The list of elements. If ``None``, take the list defined in
+            the metadata. Default is None.
+        %s
+        %s
+        %s
+        %s
+        %s
+
+        Examples
+        --------
+        >>> import exspy
+        >>> s = exspy.data.EDS_TEM_FePt_nanoparticles()
+        >>> s.print_lines()
+        +---------+------+--------------+--------+------------+
+        | Element | Line | Energy (keV) | Weight | Intensity  |
+        +---------+------+--------------+--------+------------+
+        |    Fe   |  Ka  |     6.40     |  1.00  | ########## |
+        |         |  Kb  |     7.06     |  0.13  | #          |
+        |         |  La  |     0.70     |  1.00  | ########## |
+        |         |  Ll  |     0.62     |  0.31  | ###        |
+        |         |  Ln  |     0.63     |  0.13  | #          |
+        +---------+------+--------------+--------+------------+
+        |    Pt   |  Ka  |    66.83     |  1.00  | ########## |
+        |         |  Kb  |    75.75     |  0.15  | #          |
+        |         |  La  |     9.44     |  1.00  | ########## |
+        |         | Lb1  |    11.07     |  0.41  | ####       |
+        |         | Lb2  |    11.25     |  0.22  | ##         |
+        |         |  Ma  |     2.05     |  1.00  | ########## |
+        |         |  Mb  |     2.13     |  0.59  | #####      |
+        +---------+------+--------------+--------+------------+
+
+        See also
+        --------
+        print_lines_near_energy, exspy.utils.eds.get_xray_lines,
+        exspy.utils.eds.get_xray_lines_near_energy
+        """
+        if elements is None:
+            elements = self.metadata.get_item("Sample.elements")
+            if elements is None:
+                raise ValueError(
+                    "No elements provided and no elements defined in the metadata. "
+                    "Please provide a list of elements or set them in the metadata."
+                )
+
+        utils_eds.print_lines(
+            elements=elements,
+            weight_threshold=weight_threshold,
+            only_lines=only_lines,
+            energy_range=energy_range,
+            sorting=sorting,
+            float_format=float_format,
+        )
+
+    print_lines.__doc__ %= (
+        WEIGHT_THRESHOLD_PARAMETER.replace("    ", "        "),
+        ENERGY_RANGE_PARAMETER.replace("    ", "        "),
+        ONLY_LINES_PARAMETER.replace("    ", "        "),
+        SORTING_PARAMETER.replace("    ", "        "),
+        FLOAT_FORMAT_PARAMETER.replace("    ", "        "),
+    )
 
 
 class LazyEDSSpectrum(EDSSpectrum, LazySignal1D):

--- a/exspy/tests/misc/test_eds.py
+++ b/exspy/tests/misc/test_eds.py
@@ -18,7 +18,13 @@
 
 import numpy as np
 
-from exspy._misc.eds.utils import get_xray_lines_near_energy, take_off_angle
+from exspy._misc.eds.utils import (
+    get_xray_lines,
+    get_xray_lines_near_energy,
+    print_lines,
+    print_lines_near_energy,
+    take_off_angle,
+)
 
 
 def test_xray_lines_near_energy():
@@ -81,4 +87,74 @@ def test_takeoff_angle():
     np.testing.assert_allclose(40.0, take_off_angle(0.0, 90.0, 10.0, beta_tilt=30.0))
     np.testing.assert_allclose(
         73.15788376370121, take_off_angle(45.0, 45.0, 45.0, 45.0)
+    )
+
+
+def test_get_xray_lines():
+    lines = get_xray_lines(elements=["Fe"], weight_threshold=0.5)
+    assert lines.as_dictionary() == {
+        "Fe": {
+            "Ka": {"energy (keV)": 6.4039, "weight": 1.0},
+            "La": {"energy (keV)": 0.7045, "weight": 1.0},
+        }
+    }
+
+    lines = get_xray_lines(elements=["Fe", "Pt"], weight_threshold=0.5)
+    assert lines.as_dictionary() == {
+        "Fe": {
+            "Ka": {"energy (keV)": 6.4039, "weight": 1.0},
+            "La": {"energy (keV)": 0.7045, "weight": 1.0},
+        },
+        "Pt": {
+            "Ka": {"energy (keV)": 66.8311, "weight": 1.0},
+            "La": {"energy (keV)": 9.4421, "weight": 1.0},
+            "Ma": {"energy (keV)": 2.0505, "weight": 1.0},
+            "Mb": {"energy (keV)": 2.1276, "weight": 0.59443},
+        },
+    }
+
+
+def test_print_lines_near_energy(capsys):
+    # Just test that it runs without error
+    print_lines_near_energy(energy=6.4)
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """+---------+------+--------------+--------+------------+
+| Element | Line | Energy (keV) | Weight | Intensity  |
++---------+------+--------------+--------+------------+
+|    Sm   | Lb3  |     6.32     |  0.13  | #          |
+|    Pm   | Lb2  |     6.34     |  0.20  | #          |
+|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
+|    Eu   | Lb1  |     6.46     |  0.44  | ####       |
+|    Mn   |  Kb  |     6.49     |  0.13  | #          |
+|    Dy   |  La  |     6.50     |  1.00  | ########## |
++---------+------+--------------+--------+------------+
+"""
+    )
+
+
+def test_print_lines(capsys):
+    print_lines(elements=["Fe", "Pt"])
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """+---------+------+--------------+--------+------------+
+| Element | Line | Energy (keV) | Weight | Intensity  |
++---------+------+--------------+--------+------------+
+|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
+|         |  Kb  |     7.06     |  0.13  | #          |
+|         |  La  |     0.70     |  1.00  | ########## |
+|         |  Ll  |     0.62     |  0.31  | ###        |
+|         |  Ln  |     0.63     |  0.13  | #          |
++---------+------+--------------+--------+------------+
+|    Pt   |  Ka  |    66.83     |  1.00  | ########## |
+|         |  Kb  |    75.75     |  0.15  | #          |
+|         |  La  |     9.44     |  1.00  | ########## |
+|         | Lb1  |    11.07     |  0.41  | ####       |
+|         | Lb2  |    11.25     |  0.22  | ##         |
+|         |  Ma  |     2.05     |  1.00  | ########## |
+|         |  Mb  |     2.13     |  0.59  | #####      |
++---------+------+--------------+--------+------------+
+"""
     )

--- a/exspy/tests/signals/test_eds_sem.py
+++ b/exspy/tests/signals/test_eds_sem.py
@@ -414,3 +414,57 @@ class Test_energy_units:
         np.testing.assert_allclose(
             s._get_line_energy("Al_Ka", FWHM_MnKa=128), (1.4865, 0.073167615787314)
         )
+
+
+def test_print_lines_near_energy(capsys):
+    s = EDSSEMSpectrum(np.ones(1024))
+    s.print_lines_near_energy(energy=6.4)
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """+---------+------+--------------+--------+------------+
+| Element | Line | Energy (keV) | Weight | Intensity  |
++---------+------+--------------+--------+------------+
+|    Sm   | Lb3  |     6.32     |  0.13  | #          |
+|    Pm   | Lb2  |     6.34     |  0.20  | #          |
+|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
+|    Eu   | Lb1  |     6.46     |  0.44  | ####       |
+|    Mn   |  Kb  |     6.49     |  0.13  | #          |
+|    Dy   |  La  |     6.50     |  1.00  | ########## |
++---------+------+--------------+--------+------------+
+"""
+    )
+
+
+def test_print_lines(capsys):
+    s = EDSSEMSpectrum(np.ones(1024))
+    s.set_elements(["Fe", "Pt"])
+    s.print_lines()
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """+---------+------+--------------+--------+------------+
+| Element | Line | Energy (keV) | Weight | Intensity  |
++---------+------+--------------+--------+------------+
+|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
+|         |  Kb  |     7.06     |  0.13  | #          |
+|         |  La  |     0.70     |  1.00  | ########## |
+|         |  Ll  |     0.62     |  0.31  | ###        |
+|         |  Ln  |     0.63     |  0.13  | #          |
++---------+------+--------------+--------+------------+
+|    Pt   |  Ka  |    66.83     |  1.00  | ########## |
+|         |  Kb  |    75.75     |  0.15  | #          |
+|         |  La  |     9.44     |  1.00  | ########## |
+|         | Lb1  |    11.07     |  0.41  | ####       |
+|         | Lb2  |    11.25     |  0.22  | ##         |
+|         |  Ma  |     2.05     |  1.00  | ########## |
+|         |  Mb  |     2.13     |  0.59  | #####      |
++---------+------+--------------+--------+------------+
+"""
+    )
+
+
+def test_print_lines_no_elements():
+    s = EDSSEMSpectrum(np.ones(1024))
+    with pytest.raises(ValueError):
+        s.print_lines()

--- a/exspy/utils/eds.py
+++ b/exspy/utils/eds.py
@@ -20,7 +20,10 @@
 from exspy._misc.eds.utils import (
     cross_section_to_zeta,
     electron_range,
+    get_xray_lines,
     get_xray_lines_near_energy,
+    print_lines,
+    print_lines_near_energy,
     take_off_angle,
     xray_range,
     zeta_to_cross_section,
@@ -30,7 +33,10 @@ from exspy._misc.eds.utils import (
 __all__ = [
     "cross_section_to_zeta",
     "electron_range",
+    "get_xray_lines",
     "get_xray_lines_near_energy",
+    "print_lines",
+    "print_lines_near_energy",
     "take_off_angle",
     "xray_range",
     "zeta_to_cross_section",

--- a/upcoming_changes/150.new.rst
+++ b/upcoming_changes/150.new.rst
@@ -1,0 +1,7 @@
+Add convenience functionalities to get X-ray lines information:
+
+- :func:`~.utils.eds.get_xray_lines`
+- :func:`~.utils.eds.print_lines`
+- :func:`~.utils.eds.print_lines_near_energy`
+- :meth:`~.signals.EDSSpectrum.print_lines`
+- :meth:`~.signals.EDSSpectrum.print_lines_near_energy`


### PR DESCRIPTION
### Progress of the PR
- [x] Add convenience functionalities: `get_xray_lines`, `print_lines` and `print_lines_near_energy`
- [x] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

### Minimal example of the bug fix or the new feature

Show the X-ray lines near 6.4 keV:
```python
>>> import exspy
>>> exspy.utils.eds.print_lines_near_energy(energy=6.4)
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Sm   | Lb3  |     6.32     |  0.13  | #          |
|    Pm   | Lb2  |     6.34     |  0.20  | #          |
|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
|    Eu   | Lb1  |     6.46     |  0.44  | ####       |
|    Mn   |  Kb  |     6.49     |  0.13  | #          |
|    Dy   |  La  |     6.50     |  1.00  | ########## |
+---------+------+--------------+--------+------------+
```

Show the main (high weight) X-ray lines near 6.4 keV:
```python
>>> exspy.utils.eds.print_lines_near_energy(energy=6.4, weight_threshold=0.5)
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
|    Dy   |  La  |     6.50     |  1.00  | ########## |
+---------+------+--------------+--------+------------+
```

Show all X-ray lines for a given element
```python
>>> exspy.utils.eds.print_lines(elements=["Fe"])
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
|         |  Kb  |     7.06     |  0.13  | #          |
|         |  La  |     0.70     |  1.00  | ########## |
|         |  Ll  |     0.62     |  0.31  | ###        |
|         |  Ln  |     0.63     |  0.13  | #          |
+---------+------+--------------+--------+------------+
```


Show all X-ray lines for multiple elements
```python 
>>> exspy.utils.eds.print_lines(elements=["Fe", "Pt"])
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
|         |  Kb  |     7.06     |  0.13  | #          |
|         |  La  |     0.70     |  1.00  | ########## |
|         |  Ll  |     0.62     |  0.31  | ###        |
|         |  Ln  |     0.63     |  0.13  | #          |
+---------+------+--------------+--------+------------+
|    Pt   |  Ka  |    66.83     |  1.00  | ########## |
|         |  Kb  |    75.75     |  0.15  | #          |
|         |  La  |     9.44     |  1.00  | ########## |
|         | Lb1  |    11.07     |  0.41  | ####       |
|         | Lb2  |    11.25     |  0.22  | ##         |
|         |  Ma  |     2.05     |  1.00  | ########## |
|         |  Mb  |     2.13     |  0.59  | #####      |
+---------+------+--------------+--------+------------+
```

Show all X-ray lines from a signal of the elements defined in the metadata
```python
>>> s = exspy.data.EDS_TEM_FePt_nanoparticles()
>>> s.print_lines()
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Fe   |  Ka  |     6.40     |  1.00  | ########## |
|         |  Kb  |     7.06     |  0.13  | #          |
|         |  La  |     0.70     |  1.00  | ########## |
|         |  Ll  |     0.62     |  0.31  | ###        |
|         |  Ln  |     0.63     |  0.13  | #          |
+---------+------+--------------+--------+------------+
|    Pt   |  Ka  |    66.83     |  1.00  | ########## |
|         |  Kb  |    75.75     |  0.15  | #          |
|         |  La  |     9.44     |  1.00  | ########## |
|         | Lb1  |    11.07     |  0.41  | ####       |
|         | Lb2  |    11.25     |  0.22  | ##         |
|         |  Ma  |     2.05     |  1.00  | ########## |
|         |  Mb  |     2.13     |  0.59  | #####      |
+---------+------+--------------+--------+------------+
```

Display the X-ray lines closed to 8 keV, which corresponds to the Cu Kα line
coming the from the TEM grid
```python
>>> s = exspy.data.EDS_TEM_FePt_nanoparticles()
>>> s.print_lines_near_energy(8.0)
+---------+------+--------------+--------+------------+
| Element | Line | Energy (keV) | Weight | Intensity  |
+---------+------+--------------+--------+------------+
|    Ho   | Lb2  |     7.91     |  0.24  | ##         |
|    Er   | Lb3  |     7.94     |  0.13  | #          |
|    Cu   |  Ka  |     8.05     |  1.00  | ########## |
+---------+------+--------------+--------+------------+
```


