### PR TITLE
Add preferences to API reference and add note about Hartree-Slater GOS

### DIFF
--- a/doc/reference/exspy.rst
+++ b/doc/reference/exspy.rst
@@ -1,0 +1,26 @@
+:mod:`exspy`
+------------
+
+.. currentmodule:: exspy
+
+.. automodule:: exspy
+   :members:
+
+.. figure::  ../user_guide/images/EDS_preferences_gui.png
+   :align:   center
+   :width:   300
+
+   EDS preferences window
+
+.. _exspy_preferences-label:
+
+eXSpy preferences
+^^^^^^^^^^^^^^^^^
+
+The exspy preferences has two configuration tabs for EDS and EELS:
+
+.. autoclass:: exspy._defaults_parser.EDSConfig
+    :members:
+
+.. autoclass:: exspy._defaults_parser.EELSConfig
+    :members:

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -8,6 +8,7 @@ Reference
    :caption: Reference
    :maxdepth: 2
 
+   exspy
    components
    data
    material

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -144,8 +144,10 @@ or through the GUI:
    EDS microscope parameters preferences window
 
 Any microscope and detector parameters that are not found in the imported file
-will be set by default. These default values can be changed in the
+will be set to default values. These default values can be changed in the `eXSpy`
 :py:attr:`~.exspy.preferences`.
+
+For example, the EDS detector elevation angle can be set using:
 
 .. code-block:: python
 

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -145,8 +145,7 @@ or through the GUI:
 
 Any microscope and detector parameters that are not found in the imported file
 will be set by default. These default values can be changed in the
-:py:class:`~._defaults_parser.Preferences` class (see :external+hyperspy:ref:`preferences
-<configuring-hyperspy-label>`).
+:py:attr:`~.exspy.preferences`.
 
 .. code-block:: python
 

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -293,6 +293,17 @@ the following example download a previous version (1.0) of the GOS file from Zen
     >>> m = s.create_model(gos_file_path=GOSH10)
 
 
+.. note::
+
+    The Hartree-Slater GOS files as provided by Gatan DigitalMicrograph Suite
+    v1.x and v2.x can also be used, but they are not freely distributable.
+    If you have access to the GOS files, you can set the path to the directory
+    containing the Hartree-Slater GOS files in the :py:attr:`~.exspy.preferences`.
+    More recent versions of Gatan DigitalMicrograph Suite (v3.x and above)
+    use a different proprietary format that is not supported. See discussion
+    in https://github.com/hyperspy/exspy/discussions/91 for more details.
+
+
 Fitting model
 ^^^^^^^^^^^^^
 

--- a/exspy/__init__.py
+++ b/exspy/__init__.py
@@ -16,6 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+"""
+Attributes
+----------
+__version__ : str
+    The version of the eXSpy package.
+preferences :
+    The global preferences for eXSpy, where the default settings are stored.
+
+Examples
+--------
+
+To set a preference value, for example setting the EDS detector elevation
+angle to 15 degrees:
+
+>>> exspy.preferences.EDS.eds_detector_elevation = 15.0
+
+To open the preferences dialog. To enable GUI widgets, see the hyperspy
+documentation for :external+hyperspy:ref:`configuring HyperSpy <configuring-hyperspy-label>`.
+
+>>> exspy.preferences.gui()
+
+"""
+
 from importlib.metadata import version
 from pathlib import Path
 

--- a/exspy/__init__.py
+++ b/exspy/__init__.py
@@ -32,7 +32,7 @@ angle to 15 degrees:
 
 >>> exspy.preferences.EDS.eds_detector_elevation = 15.0
 
-To open the preferences dialog. To enable GUI widgets, see the hyperspy
+To open the preferences dialog. Requires GUI widgets, to enable them see the hyperspy
 documentation for :external+hyperspy:ref:`configuring HyperSpy <configuring-hyperspy-label>`.
 
 >>> exspy.preferences.gui()

--- a/exspy/_defaults_parser.py
+++ b/exspy/_defaults_parser.py
@@ -53,14 +53,40 @@ def guess_gos_path():
 
 
 class EELSConfig(t.HasTraits):
+    """
+    Configuration options for EELS.
+
+    Attributes
+    ----------
+    eels_gos_files_path : str
+        Path to the directory containing the Hartree-Slater GOS files as provided
+        by Gatan DigitalMicrograph Suite v1.x and v2.x, more recent versions
+        are not supported.
+    """
+
     eels_gos_files_path = t.Directory(
         guess_gos_path(),
-        label="Hartree-Slater GOS directory",
+        label="Hartree-Slater GOS directory (GMS v1 and v2)",
         desc="The GOS files are used to create the EELS edge components",
     )
 
 
 class EDSConfig(t.HasTraits):
+    """
+    Configuration options for EDS.
+
+    Attributes
+    ----------
+    eds_mn_ka : float
+        Energy resolution at Mn Ka in eV.
+    eds_tilt_stage : float
+        Stage tilt in degree.
+    eds_detector_azimuth : float
+        Azimuth angle in degree.
+    eds_detector_elevation : float
+        Elevation angle in degree.
+    """
+
     eds_mn_ka = t.CFloat(
         130.0,
         label="Energy resolution at Mn Ka (eV)",

--- a/upcoming_changes/151.doc.rst
+++ b/upcoming_changes/151.doc.rst
@@ -1,0 +1,1 @@
+Add :attr:`~.preferences` to API reference and add a note explaining that only Hartree-Slater GOS from Gatan DigitalMicrograph Suite v1.x and v2.x are supported.


### PR DESCRIPTION
### Progress of the PR
- [x] Add preferences to API reference,
- [x] add note about Hartree-Slater GOS that only Gatan DigitalMicrograph Suite v1.x and v2.x are supported - see https://github.com/hyperspy/exspy/discussions/91 for context (closes #95),
- [x] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [n/a] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.



