### PR TITLE
Workaround for Zenodo rate limits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
 
   Push:
     needs: Build
-    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'hyperspy' }}
+    if: ${{ github.ref_name == 'main' && github.repository_owner == 'hyperspy' }}
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ jobs:
   Build:
     # Use the "reusable workflow" from the hyperspy organisation
     uses: hyperspy/.github/.github/workflows/doc.yml@main
+    with:
+      CACHE_POOCH: 'pooch'
 
   Push:
     needs: Build

--- a/.github/workflows/package_and_test.yml
+++ b/.github/workflows/package_and_test.yml
@@ -1,8 +1,8 @@
-name: Package & Test
+# name: Package & Test
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
-jobs:
-  package_and_test:
-    # Use the "reusable workflow" from the hyperspy organisation
-    uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
+# jobs:
+#   package_and_test:
+#     # Use the "reusable workflow" from the hyperspy organisation
+#     uses: hyperspy/.github/.github/workflows/package_and_test.yml@main

--- a/.github/workflows/package_and_test.yml
+++ b/.github/workflows/package_and_test.yml
@@ -1,8 +1,10 @@
-# name: Package & Test
+name: Package & Test
 
-# on: [push, pull_request]
+on: [push, pull_request]
 
-# jobs:
-#   package_and_test:
-#     # Use the "reusable workflow" from the hyperspy organisation
-#     uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
+jobs:
+  package_and_test:
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/package_and_test.yml@main
+    with:
+      CACHE_POOCH: 'pooch'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,30 +17,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
-        PYTHON_VERSION: ['3.10', '3.12']
+        # os: [ubuntu, windows, macos]
+        os: [ubuntu]
+        # PYTHON_VERSION: ['3.10', '3.12']
+        PYTHON_VERSION: ['3.12']
         LABEL: ['']
         PIP_SELECTOR: ['[tests, speed]']
-        include:
-          - os: ubuntu
-            PYTHON_VERSION: '3.9'
-            PIP_SELECTOR: '[tests, speed]'
-          - os: ubuntu
-            PYTHON_VERSION: '3.11'
-            PIP_SELECTOR: '[tests, speed]'
-          - os: ubuntu
-            PYTHON_VERSION: '3.13'
-            PIP_SELECTOR: '[tests, speed]'
-          # test with hyperspy dev branch
-          - os: ubuntu
-            PYTHON_VERSION: '3.12'
-            PIP_SELECTOR: '[tests]'
-            LABEL: '-dev'
-          # test minimum requirement
-          - os: ubuntu
-            PYTHON_VERSION: '3.9'
-            LABEL: '-minimum'
-            PIP_SELECTOR: '[tests]'
+        # include:
+        #   - os: ubuntu
+        #     PYTHON_VERSION: '3.9'
+        #     PIP_SELECTOR: '[tests, speed]'
+        #   - os: ubuntu
+        #     PYTHON_VERSION: '3.11'
+        #     PIP_SELECTOR: '[tests, speed]'
+        #   - os: ubuntu
+        #     PYTHON_VERSION: '3.13'
+        #     PIP_SELECTOR: '[tests, speed]'
+        #   # test with hyperspy dev branch
+        #   - os: ubuntu
+        #     PYTHON_VERSION: '3.12'
+        #     PIP_SELECTOR: '[tests]'
+        #     LABEL: '-dev'
+        #   # test minimum requirement
+        #   - os: ubuntu
+        #     PYTHON_VERSION: '3.9'
+        #     LABEL: '-minimum'
+        #     PIP_SELECTOR: '[tests]'
 
     steps:
       - uses: actions/checkout@v6
@@ -80,13 +82,30 @@ jobs:
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
 
+      - name: Get pooch cache paths
+        run: |
+          # create list of pooch cache paths as a string (space separated)
+          python -c "import pooch; print(str(pooch.os_cache('pooch')))" > pooch_cache_paths.txt
+          echo "POOCH_CACHE_PATHS=$(cat pooch_cache_paths.txt)" >> $GITHUB_ENV
+
+      - name: Cache GOS data
+        uses: actions/cache@v4
+        env:
+          # Increase this value to reset cache
+          CACHE_NUMBER: 0
+        with:
+          path: ${{ env.POOCH_CACHE_PATHS }}
+          key: GOS_cache-${{ env.CACHE_NUMBER }}
+          restore-keys: |
+            GOS_cache-${{ env.CACHE_NUMBER }}
+
       - name: Pip list
         run: |
           pip list
 
       - name: Run test suite
         run: |
-          pytest --pyargs exspy -n 2 --cov=. --cov-report=xml
+          pytest --pyargs exspy --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           # test with hyperspy dev branch
           - os: ubuntu
             PYTHON_VERSION: '3.12'
-            PIP_SELECTOR: '[tests]'
+            PIP_SELECTOR: '[tests, speed]'
             LABEL: '-dev'
           # test minimum requirement
           - os: ubuntu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run test suite
         run: |
-          pytest --pyargs exspy --cov=. --cov-report=xml
+          pytest --pyargs exspy -n 2 --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,37 +12,38 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash -el {0}
     env:
       MPLBACKEND: agg
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu, windows, macos]
-        os: [ubuntu]
-        # PYTHON_VERSION: ['3.10', '3.12']
-        PYTHON_VERSION: ['3.12']
+        os: [ubuntu, windows, macos]
+        PYTHON_VERSION: ['3.10', '3.12']
         LABEL: ['']
         PIP_SELECTOR: ['[tests, speed]']
-        # include:
-        #   - os: ubuntu
-        #     PYTHON_VERSION: '3.9'
-        #     PIP_SELECTOR: '[tests, speed]'
-        #   - os: ubuntu
-        #     PYTHON_VERSION: '3.11'
-        #     PIP_SELECTOR: '[tests, speed]'
-        #   - os: ubuntu
-        #     PYTHON_VERSION: '3.13'
-        #     PIP_SELECTOR: '[tests, speed]'
-        #   # test with hyperspy dev branch
-        #   - os: ubuntu
-        #     PYTHON_VERSION: '3.12'
-        #     PIP_SELECTOR: '[tests]'
-        #     LABEL: '-dev'
-        #   # test minimum requirement
-        #   - os: ubuntu
-        #     PYTHON_VERSION: '3.9'
-        #     LABEL: '-minimum'
-        #     PIP_SELECTOR: '[tests]'
+        include:
+          - os: ubuntu
+            PYTHON_VERSION: '3.9'
+            PIP_SELECTOR: '[tests, speed]'
+          - os: ubuntu
+            PYTHON_VERSION: '3.11'
+            PIP_SELECTOR: '[tests, speed]'
+          - os: ubuntu
+            PYTHON_VERSION: '3.13'
+            PIP_SELECTOR: '[tests, speed]'
+          # test with hyperspy dev branch
+          - os: ubuntu
+            PYTHON_VERSION: '3.12'
+            PIP_SELECTOR: '[tests]'
+            LABEL: '-dev'
+          # test minimum requirement
+          - os: ubuntu
+            PYTHON_VERSION: '3.9'
+            LABEL: '-minimum'
+            PIP_SELECTOR: '[tests]'
 
     steps:
       - uses: actions/checkout@v6
@@ -50,7 +51,6 @@ jobs:
           fetch-depth: 0
 
       - name: get repository name
-        shell: bash
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Fetch tags upstream
@@ -78,7 +78,6 @@ jobs:
       - name: Install (HyperSpy dev)
         # Test against the hyperspy `RELEASE_next_minor` branch
         if: contains( matrix.LABEL, 'dev')
-        shell: bash
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
 
@@ -95,9 +94,8 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: ${{ env.POOCH_CACHE_PATHS }}
-          key: GOS_cache-${{ env.CACHE_NUMBER }}
-          restore-keys: |
-            GOS_cache-${{ env.CACHE_NUMBER }}
+          key: ${{ runner.os }}-GOS_cache-${{ env.CACHE_NUMBER }}
+          restore-keys:  ${{ runner.os }}-GOS_cache
 
       - name: Pip list
         run: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,7 @@ import numpydoc
 from datetime import datetime
 from packaging.version import Version
 
+from exspy._misc import _download_GOS_files
 
 # -- Project information -----------------------------------------------------
 
@@ -172,3 +173,5 @@ import hyperspy.api as hs
 import exspy
 import numpy as np
 """
+
+_download_GOS_files(download_all=False)

--- a/examples/model_fitting/EELS_curve_fitting.py
+++ b/examples/model_fitting/EELS_curve_fitting.py
@@ -18,15 +18,18 @@ s.set_microscope_parameters(
     beam_energy=300, convergence_angle=24.6, collection_angle=13.6
 )
 
+# %%
+# Create a model and fit it to the data.
+#
+# .. note::
+#
+#    By default, :ref:`generalized oscillator strength (GOS) <eels.GOS>` calculated using density functional theory (DFT)
+#    are used. Use the ``GOS`` parameter to change to use other GOS, for example ``GOS="dirac"``.
+
 m = s.create_model(low_loss=low_loss)
 m.enable_fine_structure()
 m.multifit(kind="smart")
-m.plot()
-
-# one can also use the Dirac GOS by specifying the GOS parameter
-m = s.create_model(low_loss=low_loss, GOS="dirac")
-m.enable_fine_structure()
-m.multifit(kind="smart")
-m.plot()
 
 # %%
+# Plot the model fit result
+m.plot()

--- a/exspy/_misc/__init__.py
+++ b/exspy/_misc/__init__.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2025 The eXSpy developers
+#
+# This file is part of eXSpy.
+#
+# eXSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# eXSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+from time import sleep
+
+import pooch
+
+
+def _download_GOS_files(download_all=True):
+    """
+    Download GOS files for testing purposes and building documentation.
+
+    Parameters
+    ----------
+    download_all : bool, optional
+        If True, download all GOS files. If False, download only recent GOS files.
+        Default is True.
+    """
+
+    def retry_and_sleep(url, known_hash, retries=3, sleep_time=30):
+        for attempt in range(retries):
+            try:
+                return pooch.retrieve(
+                    url=url,
+                    known_hash=known_hash,
+                    # use large chunk size to reduce number of requests to Zenodo
+                    downloader=pooch.HTTPDownloader(chunk_size=30000),
+                    progressbar=False,
+                )
+            except Exception as e:
+                if attempt < retries - 1:
+                    print(
+                        f"Download failed (attempt {attempt + 1}/{retries}). "
+                        f"Retrying in {sleep_time} seconds..."
+                    )
+                    sleep(sleep_time)
+                else:
+                    print("All download attempts failed.")
+                    raise e
+
+    print("Checking if GOS files need downloading...")
+    retry_and_sleep(
+        url="https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
+        known_hash="md5:7fee8891c147a4f769668403b54c529b",
+    )
+    if download_all:
+        retry_and_sleep(
+            url="https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
+            known_hash="md5:01a855d3750d2c063955248358dbee8d",
+        )
+        retry_and_sleep(
+            url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
+            known_hash="md5:d65d5c23142532fde0a80e160ab51574",
+        )
+    print("GOS files available.")
+
+
+__all__ = [
+    "_download_GOS_files",
+]
+
+
+def __dir__():
+    return sorted(__all__)

--- a/exspy/_misc/eels/gosh_gos.py
+++ b/exspy/_misc/eels/gosh_gos.py
@@ -34,12 +34,12 @@ a0 = constants.value("Bohr radius")
 
 _DFT_GOSH = {
     "DOI": "10.5281/zenodo.7645765",
-    "URL": "doi:10.5281/zenodo.7645765/Segger_Guzzinati_Kohl_1.5.0.gosh",
+    "URL": "https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
     "KNOWN_HASH": "md5:7fee8891c147a4f769668403b54c529b",
 }
 _DIRAC_GOSH = {
     "DOI": "10.5281/zenodo.12800856",
-    "URL": "doi:10.5281/zenodo.12800856/Dirac_GOS_compact.gosh",
+    "URL": "https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
     "KNOWN_HASH": "md5:01a855d3750d2c063955248358dbee8d",
 }
 _GOSH_SOURCES = {"dft": _DFT_GOSH, "dirac": _DIRAC_GOSH}

--- a/exspy/_misc/eels/gosh_gos.py
+++ b/exspy/_misc/eels/gosh_gos.py
@@ -110,7 +110,7 @@ class GoshGOS(TabulatedGOS):
             gos_file_path = pooch.retrieve(
                 url=_GOSH_SOURCES[source]["URL"],
                 known_hash=_GOSH_SOURCES[source]["KNOWN_HASH"],
-                downloader=pooch.HTTPDownloader(chunk_size=8192),
+                downloader=pooch.HTTPDownloader(chunk_size=30000),
                 progressbar=preferences.General.show_progressbar,
             )
         self.gos_file_path = gos_file_path

--- a/exspy/_misc/eels/gosh_gos.py
+++ b/exspy/_misc/eels/gosh_gos.py
@@ -101,11 +101,16 @@ class GoshGOS(TabulatedGOS):
 
         if gos_file_path is None:
             source = source.lower()
-            assert source in _GOSH_SOURCES.keys(), f"Invalid source: {source}"
+            if source not in _GOSH_SOURCES.keys():
+                raise ValueError(
+                    f"Invalid source: {source}, valid options are "
+                    f"{list(_GOSH_SOURCES.keys())}"
+                )
             self._name = source
             gos_file_path = pooch.retrieve(
                 url=_GOSH_SOURCES[source]["URL"],
                 known_hash=_GOSH_SOURCES[source]["KNOWN_HASH"],
+                downloader=pooch.HTTPDownloader(chunk_size=8192),
                 progressbar=preferences.General.show_progressbar,
             )
         self.gos_file_path = gos_file_path

--- a/exspy/conftest.py
+++ b/exspy/conftest.py
@@ -68,7 +68,7 @@ def _download_and_cache_GOS():
     pooch.retrieve(
         url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
         known_hash="md5:d65d5c23142532fde0a80e160ab51574",
-        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        downloader=pooch.HTTPDownloader(chunk_size=30000),
         progressbar=False,
     )
     print("sleeping 30s to throttle zenodo requests")
@@ -76,7 +76,7 @@ def _download_and_cache_GOS():
     pooch.retrieve(
         url="https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
         known_hash="md5:7fee8891c147a4f769668403b54c529b",
-        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        downloader=pooch.HTTPDownloader(chunk_size=30000),
         progressbar=False,
     )
     print("sleeping 30s to throttle zenodo requests")
@@ -84,7 +84,7 @@ def _download_and_cache_GOS():
     pooch.retrieve(
         url="https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
         known_hash="md5:01a855d3750d2c063955248358dbee8d",
-        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        downloader=pooch.HTTPDownloader(chunk_size=30000),
         progressbar=False,
     )
     print("finished download of GOS files")

--- a/exspy/conftest.py
+++ b/exspy/conftest.py
@@ -17,7 +17,6 @@
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import importlib
-from time import sleep
 
 try:
     # Set traits toolkit to work in a headless system
@@ -37,10 +36,11 @@ import matplotlib.pyplot as plt
 import pytest
 import numpy as np
 import hyperspy.api as hs
-import pooch
 
 # Use matplotlib fixture to clean up figure, setup backend, etc.
 from matplotlib.testing.conftest import mpl_test_settings  # noqa: F401
+
+from exspy._misc import _download_GOS_files
 
 
 @pytest.fixture(autouse=True)
@@ -62,45 +62,6 @@ def setup_module(mod, pdb_cmdopt):
         dask.set_options(get=dask.local.get_sync)
 
 
-def _download_and_cache_GOS():
-    """Download GOS files for testing purposes."""
-
-    def retry_and_sleep(url, known_hash, retries=3, sleep_time=30):
-        for attempt in range(retries):
-            try:
-                return pooch.retrieve(
-                    url=url,
-                    known_hash=known_hash,
-                    downloader=pooch.HTTPDownloader(chunk_size=30000),
-                    progressbar=False,
-                )
-            except Exception as e:
-                if attempt < retries - 1:
-                    print(
-                        f"Download failed (attempt {attempt + 1}/{retries}). "
-                        f"Retrying in {sleep_time} seconds..."
-                    )
-                    sleep(sleep_time)
-                else:
-                    print("All download attempts failed.")
-                    raise e
-
-    print("Start download of GOS files")
-    retry_and_sleep(
-        url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
-        known_hash="md5:d65d5c23142532fde0a80e160ab51574",
-    )
-    retry_and_sleep(
-        url="https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
-        known_hash="md5:7fee8891c147a4f769668403b54c529b",
-    )
-    retry_and_sleep(
-        url="https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
-        known_hash="md5:01a855d3750d2c063955248358dbee8d",
-    )
-    print("finished download of GOS files")
-
-
 pytest_mpl_spec = importlib.util.find_spec("pytest_mpl")
 
 
@@ -112,11 +73,9 @@ if pytest_mpl_spec is None:
             "mpl_image_compare: dummy marker registration to allow running "
             "without the pytest-mpl plugin.",
         )
-        _download_and_cache_GOS()
-
+        _download_GOS_files()
 
 else:
 
     def pytest_configure(config):
-        _download_and_cache_GOS()
-        print("finish")
+        _download_GOS_files()

--- a/exspy/conftest.py
+++ b/exspy/conftest.py
@@ -64,28 +64,39 @@ def setup_module(mod, pdb_cmdopt):
 
 def _download_and_cache_GOS():
     """Download GOS files for testing purposes."""
+
+    def retry_and_sleep(url, known_hash, retries=3, sleep_time=30):
+        for attempt in range(retries):
+            try:
+                return pooch.retrieve(
+                    url=url,
+                    known_hash=known_hash,
+                    downloader=pooch.HTTPDownloader(chunk_size=30000),
+                    progressbar=False,
+                )
+            except Exception as e:
+                if attempt < retries - 1:
+                    print(
+                        f"Download failed (attempt {attempt + 1}/{retries}). "
+                        f"Retrying in {sleep_time} seconds..."
+                    )
+                    sleep(sleep_time)
+                else:
+                    print("All download attempts failed.")
+                    raise e
+
     print("Start download of GOS files")
-    pooch.retrieve(
+    retry_and_sleep(
         url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
         known_hash="md5:d65d5c23142532fde0a80e160ab51574",
-        downloader=pooch.HTTPDownloader(chunk_size=30000),
-        progressbar=False,
     )
-    print("sleeping 30s to throttle zenodo requests")
-    sleep(30)
-    pooch.retrieve(
+    retry_and_sleep(
         url="https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
         known_hash="md5:7fee8891c147a4f769668403b54c529b",
-        downloader=pooch.HTTPDownloader(chunk_size=30000),
-        progressbar=False,
     )
-    print("sleeping 30s to throttle zenodo requests")
-    sleep(30)
-    pooch.retrieve(
+    retry_and_sleep(
         url="https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
         known_hash="md5:01a855d3750d2c063955248358dbee8d",
-        downloader=pooch.HTTPDownloader(chunk_size=30000),
-        progressbar=False,
     )
     print("finished download of GOS files")
 

--- a/exspy/conftest.py
+++ b/exspy/conftest.py
@@ -17,6 +17,7 @@
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import importlib
+from time import sleep
 
 try:
     # Set traits toolkit to work in a headless system
@@ -36,6 +37,7 @@ import matplotlib.pyplot as plt
 import pytest
 import numpy as np
 import hyperspy.api as hs
+import pooch
 
 # Use matplotlib fixture to clean up figure, setup backend, etc.
 from matplotlib.testing.conftest import mpl_test_settings  # noqa: F401
@@ -60,6 +62,34 @@ def setup_module(mod, pdb_cmdopt):
         dask.set_options(get=dask.local.get_sync)
 
 
+def _download_and_cache_GOS():
+    """Download GOS files for testing purposes."""
+    print("Start download of GOS files")
+    pooch.retrieve(
+        url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
+        known_hash="md5:d65d5c23142532fde0a80e160ab51574",
+        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        progressbar=False,
+    )
+    print("sleeping 30s to throttle zenodo requests")
+    sleep(30)
+    pooch.retrieve(
+        url="https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh",
+        known_hash="md5:7fee8891c147a4f769668403b54c529b",
+        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        progressbar=False,
+    )
+    print("sleeping 30s to throttle zenodo requests")
+    sleep(30)
+    pooch.retrieve(
+        url="https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh",
+        known_hash="md5:01a855d3750d2c063955248358dbee8d",
+        downloader=pooch.HTTPDownloader(chunk_size=8192),
+        progressbar=False,
+    )
+    print("finished download of GOS files")
+
+
 pytest_mpl_spec = importlib.util.find_spec("pytest_mpl")
 
 
@@ -71,3 +101,11 @@ if pytest_mpl_spec is None:
             "mpl_image_compare: dummy marker registration to allow running "
             "without the pytest-mpl plugin.",
         )
+        _download_and_cache_GOS()
+
+
+else:
+
+    def pytest_configure(config):
+        _download_and_cache_GOS()
+        print("finish")

--- a/exspy/tests/conftest.py
+++ b/exspy/tests/conftest.py
@@ -42,6 +42,8 @@ from matplotlib.testing.conftest import mpl_test_settings  # noqa: F401
 
 from exspy._misc import _download_GOS_files
 
+hs.preferences.General.show_progressbar = False
+
 
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):

--- a/exspy/tests/misc/test_gos.py
+++ b/exspy/tests/misc/test_gos.py
@@ -68,6 +68,11 @@ def test_gosh_not_in_conventions():
 
 
 def test_gosh_not_in_file():
+    GOSH10 = pooch.retrieve(
+        url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
+        known_hash="md5:d65d5c23142532fde0a80e160ab51574",
+        progressbar=False,
+    )
     # Use version 1.0 which doesn't have the Ac element
     with pytest.raises(ValueError):
         _ = GoshGOS("Ac_L3", gos_file_path=GOSH10)

--- a/exspy/tests/misc/test_gos.py
+++ b/exspy/tests/misc/test_gos.py
@@ -29,13 +29,6 @@ from exspy._misc.eels import HydrogenicGOS
 from exspy._misc.elements import elements
 
 
-GOSH10 = pooch.retrieve(
-    url="doi:10.5281/zenodo.6599071/Segger_Guzzinati_Kohl_1.0.0.gos",
-    known_hash="md5:d65d5c23142532fde0a80e160ab51574",
-    progressbar=False,
-)
-
-
 @pytest.mark.skipif(
     not Path(preferences.EELS.eels_gos_files_path).exists(),
     reason="Hartree-Slater GOS not available",

--- a/exspy/tests/models/test_linear_model.py
+++ b/exspy/tests/models/test_linear_model.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with eXSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+
 import numpy as np
 import pytest
 from hyperspy.decorators import lazifyTestClass

--- a/upcoming_changes/156.maintenance.rst
+++ b/upcoming_changes/156.maintenance.rst
@@ -1,0 +1,1 @@
+Implement workaround for Zenodo rate limits in eXSpy tests suite and documentation build.


### PR DESCRIPTION
Workaround for Zenodo rate limits. The GOS files are stored on Zenodo and are needed to run the test suite and build the documentation.

It is difficult to be 100% sure but from what I have tried the main things to reduce hitting the Zenodo rate limits are:
- use URL instead of DOI, most likely a pooch implementation details
- increase downloading chunksize, pooch use the request library to download files
- Force downloading files at the beginning to avoid concurrent request
- use caching on CI

## Progress of the PR
- [x] Add function to download GOS before running test suite and building documentation,
- [x] add caching on CI,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] update tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

