### PR TITLE
Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,27 +21,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        PYTHON_VERSION: ['3.10', '3.12']
+        PYTHON_VERSION: ['3.11', '3.13']
         LABEL: ['']
         PIP_SELECTOR: ['[tests, speed]']
         include:
           - os: ubuntu
-            PYTHON_VERSION: '3.9'
+            PYTHON_VERSION: '3.10'
             PIP_SELECTOR: '[tests, speed]'
           - os: ubuntu
-            PYTHON_VERSION: '3.11'
+            PYTHON_VERSION: '3.12'
             PIP_SELECTOR: '[tests, speed]'
           - os: ubuntu
-            PYTHON_VERSION: '3.13'
+            PYTHON_VERSION: '3.14'
             PIP_SELECTOR: '[tests, speed]'
           # test with hyperspy dev branch
           - os: ubuntu
-            PYTHON_VERSION: '3.12'
+            PYTHON_VERSION: '3.13'
             PIP_SELECTOR: '[tests, speed]'
             LABEL: '-dev'
           # test minimum requirement
           - os: ubuntu
-            PYTHON_VERSION: '3.9'
+            PYTHON_VERSION: '3.10'
             LABEL: '-minimum'
             PIP_SELECTOR: '[tests]'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "exspy"
 description = "EELS and EDS analysis with the HyperSpy framework"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 keywords=[
     "python",
@@ -32,11 +32,11 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "dask[array]",
@@ -69,9 +69,8 @@ file = "LICENSE"
   "sphinx-design",
   "sphinx-favicon",
   "sphinx-gallery",
-  "sphinxcontrib-towncrier",
-  # unpin when sphinxcontrib-towncrier support more recent version to towncrier
-  "towncrier<24",
+  "sphinxcontrib-towncrier>=0.5.0a0",  # towncrier 24.7.0 support
+  "towncrier",
 ]
 speed = [
     "hyperspy[speed]",

--- a/upcoming_changes/159.maintenance.rst
+++ b/upcoming_changes/159.maintenance.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.14 and drop Python 3.9.


### PR DESCRIPTION
Based on #156.

### Progress of the PR
- [x] Add explicit support for python 3.14, drop python 3.9,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [ ] ready for review.

