### PR TITLE
Improve GOS caching on CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,9 +11,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  integration_test:
+  download_exspy_GOS:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') || github.event_name == 'workflow_dispatch' }}
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/download_exspy_GOS.yml@main
+
+  download_rsciio_test_data:
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/download_rsciio_test_data.yml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        VERSION: [release, main]
+    with:
+      VERSION: ${{ matrix.VERSION }}
+
+  integration_test:
     name: hs_${{ matrix.HYPERSPY_VERSION }}-rs_${{ matrix.ROSETTASCIIO_VERSION }}-ext_${{ matrix.EXTENSION_VERSION }}
+    needs: [download_exspy_GOS, download_rsciio_test_data]  
     strategy:
       fail-fast: false
       matrix:
@@ -30,3 +45,5 @@ jobs:
       ROSETTASCIIO_VERSION: ${{ matrix.ROSETTASCIIO_VERSION }}
       PIP_EXTRAS: '[all,tests]'
       USE_CONDA: false
+      RSCIIO_CACHE_POOCH_LABEL: ${{ needs.download_rsciio_test_data.outputs.VERSION }}
+                                                                                      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,22 +9,8 @@ on:
 
 jobs:
   download_cache_GOS:
-    name: Download GOS data
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ssciwr/pooch-cache@v1
-        with:
-          # eXSpy uses pooch.retrieve to download the GOS data,
-          # so we need to use the default pooch cache
-          name: pooch
-          file-urls: |
-            https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh
-            https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh
-            https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos
-          known-hashes: |
-            md5:7fee8891c147a4f769668403b54c529b
-            md5:01a855d3750d2c063955248358dbee8d
-            md5:d65d5c23142532fde0a80e160ab51574
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/download_exspy_GOS.yml@main
 
   run_test_site:
     name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,27 @@ on:
   pull_request:
 
 jobs:
+  download_cache_GOS:
+    name: Download GOS data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ssciwr/pooch-cache@v1
+        with:
+          # eXSpy uses pooch.retrieve to download the GOS data,
+          # so we need to use the default pooch cache
+          name: pooch
+          file-urls: |
+            https://zenodo.org/records/7645765/files/Segger_Guzzinati_Kohl_1.5.0.gosh
+            https://zenodo.org/records/12800856/files/Dirac_GOS_compact.gosh
+            https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos
+          known-hashes: |
+            md5:7fee8891c147a4f769668403b54c529b
+            md5:01a855d3750d2c063955248358dbee8d
+            md5:d65d5c23142532fde0a80e160ab51574
+
   run_test_site:
     name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
+    needs: [download_cache_GOS]
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 30
     defaults:
@@ -61,6 +80,11 @@ jobs:
           git remote add upstream https://github.com/hyperspy/${{ env.REPOSITORY_NAME }}.git
           git fetch upstream --tags
 
+      - uses: ssciwr/pooch-cache@v1
+        with:
+          name: pooch
+          fail-on-cache-miss: true
+
       - uses: actions/setup-python@v6
         name: Install Python
         with:
@@ -80,22 +104,6 @@ jobs:
         if: contains( matrix.LABEL, 'dev')
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
-
-      - name: Get pooch cache paths
-        run: |
-          # create list of pooch cache paths as a string (space separated)
-          python -c "import pooch; print(str(pooch.os_cache('pooch')))" > pooch_cache_paths.txt
-          echo "POOCH_CACHE_PATHS=$(cat pooch_cache_paths.txt)" >> $GITHUB_ENV
-
-      - name: Cache GOS data
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache
-          CACHE_NUMBER: 0
-        with:
-          path: ${{ env.POOCH_CACHE_PATHS }}
-          key: ${{ runner.os }}-GOS_cache-${{ env.CACHE_NUMBER }}
-          restore-keys:  ${{ runner.os }}-GOS_cache
 
       - name: Pip list
         run: |

--- a/upcoming_changes/164.maintenance.rst
+++ b/upcoming_changes/164.maintenance.rst
@@ -1,0 +1,1 @@
+Improve caching of GOS files on GitHub CI by sharing cache across different jobs.


### PR DESCRIPTION
### Progress of the PR
- [x] Share cache across CI matrix,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

@CSSFrancis, this is an improvement of caching data from zenodo using https://github.com/ssciwr/pooch-cache.
