### PR TITLE
Skip test when download of GOS time out in test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 *.pyc
 .spyproject/*
 *__pycache__*
+.vscode/*

--- a/exspy/tests/misc/test_gos.py
+++ b/exspy/tests/misc/test_gos.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import h5py
 import pooch
 import pytest
+import requests
 
 from exspy._defaults_parser import preferences
 from exspy._misc.eels.gosh_gos import GoshGOS
@@ -61,11 +62,14 @@ def test_gosh_not_in_conventions():
 
 
 def test_gosh_not_in_file():
-    GOSH10 = pooch.retrieve(
-        url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
-        known_hash="md5:d65d5c23142532fde0a80e160ab51574",
-        progressbar=False,
-    )
+    try:
+        GOSH10 = pooch.retrieve(
+            url="https://zenodo.org/records/6599071/files/Segger_Guzzinati_Kohl_1.0.0.gos",
+            known_hash="md5:d65d5c23142532fde0a80e160ab51574",
+            progressbar=False,
+        )
+    except requests.exceptions.ReadTimeout:  # pragma: no cover
+        pytest.skip("Download of GOS file timed out.")
     # Use version 1.0 which doesn't have the Ac element
     with pytest.raises(ValueError):
         _ = GoshGOS("Ac_L3", gos_file_path=GOSH10)


### PR DESCRIPTION
Fix https://github.com/hyperspy/hyperspy-extensions-list/issues/87.