### PR TITLE
ENH: Add `ssd` parameter to `fourier_log_deconvolution`

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -140,6 +140,74 @@ Three deconvolution methods are currently available:
 * :py:meth:`~.signals.EELSSpectrum.fourier_ratio_deconvolution`
 * :py:meth:`~.signals.EELSSpectrum.richardson_lucy_deconvolution`
 
+Fourier-log deconvolution
+"""""""""""""""""""""""""
+
+The Fourier-log method (:ref:`[Egerton2011] <Egerton2011>`, §4.4) recovers the
+inelastic scattering distribution from a low-loss spectrum.  It is the de facto
+standard for plural-scattering deconvolution in EELS.
+
+By default ``fourier_log_deconvolution()`` returns ``J¹(E)``, the
+single-scattering intensity scaled by the zero-loss integral:
+
+.. code-block:: python
+
+    >>> j1 = s.fourier_log_deconvolution(zlp=low_loss)
+
+    # j1 is J¹(E).  Its integral equals I₀·t/λ:
+    >>> print(j1.data.sum())
+    104284.3
+
+``J¹(E)`` is the correct quantity for most workflows — it has the same units
+as the input spectrum and may be used for elemental quantification provided
+:math:`I_0` is included in the formula (see the warning below).
+
+To obtain the true single-scattering distribution ``S(E)`` — whose integral
+equals the thickness ratio ``t/λ`` — pass ``ssd=True``:
+
+.. code-block:: python
+
+    >>> ssd = s.fourier_log_deconvolution(zlp=low_loss, ssd=True)
+
+    # ssd is S(E).  Its integral equals t/λ:
+    >>> print(ssd.data.sum())
+    0.364
+
+The relationship between the two forms is:
+
+.. math::
+
+    J^1(E) = I_0 \cdot S(E), \qquad
+    I_0 = \int Z(E) \, \mathrm dE
+
+where ``I₀`` is the total elastic intensity (ZLP integral) and ``t/λ`` is the
+ratio of the sample thickness to the inelastic mean free path.
+
+.. warning::
+
+   **Do not omit** :math:`I_0` **in quantification.**  The default output
+   ``J¹(E)`` includes the ZLP integral as a multiplicative factor.
+   Quantifying an element with the edge integral of ``J¹(E)`` requires
+   dividing by :math:`I_0`:
+
+   .. math::
+
+       N_k = \frac{ \int_\text{edge} J^1(E)\,\mathrm dE }
+                    { I_0 \cdot \sigma_k(\beta, \Delta) }
+
+   where :math:`\sigma_k` is the partial cross-section for edge *k*.
+
+   If you omit :math:`I_0` and use :math:`N_k = \int J^1 / \sigma_k`, the
+   areal density will be incorrect by the factor :math:`I_0` (typically
+   :math:`10^4`–:math:`10^6`).  To avoid this, either:
+
+   - **supply** :math:`I_0` from ``zlp.data.sum()`` or
+     :meth:`~.signals.EELSSpectrum.estimate_elastic_scattering_intensity`, or
+   - **pass ``ssd=True``** to ``fourier_log_deconvolution`` — the output
+     ``S(E)`` is already normalised so that
+     :math:`\int_\text{edge} S(E) = t/\lambda_k` and
+     :math:`N_k = \int_\text{edge} S(E) / \sigma_k`.
+
 .. minigallery:: ../examples/EELS/fourier_ratio_deconvolution*
 
 

--- a/exspy/signals/_eels.py
+++ b/exspy/signals/_eels.py
@@ -867,24 +867,53 @@ class EELSSpectrum(Signal1D):
         s.set_signal_type("")
         return s
 
-    def fourier_log_deconvolution(self, zlp, add_zlp=False, crop=False):
-        """Performs fourier-log deconvolution.
+    def fourier_log_deconvolution(self, zlp, add_zlp=False, crop=False, ssd=False):
+        """Perform Fourier-log deconvolution.
+
+        By default this method returns the single-scattering component
+        :math:`J^1(E)`, the spectrum that would be recorded in the absence
+        of plural scattering (Egerton 2011, §4.4):
+
+            :math:`J^1(E) = I_0 \\cdot S(E)`
+
+        where :math:`I_0 = \\int Z(E)\\,dE` is the ZLP integral and
+        :math:`S(E)` is the single-scattering distribution (SSD).  The
+        total scattered intensity is :math:`\\int J^1(E)\\,dE = I_0 \\cdot
+        t/\\lambda`.
+
+        Setting ``ssd=True`` divides the result by :math:`I_0` to recover
+        the SSD directly, whose integral equals :math:`t/\\lambda`:
+
+            :math:`S(E) = J^1(E)\\,/\\,I_0`
+
+        Use ``ssd=True`` when the deconvolved spectrum is needed for
+        absolute areal-density quantification or when comparing spectra
+        acquired at different beam currents.
 
         Parameters
         ----------
         zlp : EELSSpectrum
             The corresponding zero-loss peak.
-
-        add_zlp : bool
-            If True, adds the ZLP to the deconvolved spectrum
-        crop : bool
-            If True crop the spectrum to leave out the channels that
-            have been modified to decay smoothly to zero at the sides
-            of the spectrum.
+        add_zlp : bool, default=False
+            If True, adds the ZLP to the deconvolved spectrum.  Useful
+            when the ZLP region should contain the original zero-loss
+            signal (e.g. for display of low-loss spectra).
+        crop : bool, default=False
+            If True, crop the spectrum to discard the channels that have
+            been modified by the Hanning taper at the sides of the
+            spectrum.
+        ssd : bool, default=False
+            If False (default), returns :math:`J^1(E)`, the single-
+            scattering component normalised to the ZLP integral (sum
+            equals :math:`I_0 \\cdot t/\\lambda`).
+            If True, divides by :math:`I_0` to recover the single-
+             scattering distribution (sum equals :math:`t/\\lambda`).
 
         Returns
         -------
-        An EELSSpectrum containing the current data deconvolved.
+        EELSSpectrum
+            The deconvolved spectrum.  By default this is :math:`J^1(E)`;
+            with ``ssd=True`` it is :math:`S(E)`.
 
         Raises
         ------
@@ -893,8 +922,8 @@ class EELSSpectrum(Signal1D):
 
         Notes
         -----
-        For details see: Egerton, R. Electron Energy-Loss
-        Spectroscopy in the Electron Microscope. Springer-Verlag, 2011.
+        For details see: Egerton, R. *Electron Energy-Loss Spectroscopy in
+        the Electron Microscope*.  Springer-Verlag, 2011, §4.4.
 
         """
         import dask.array as da
@@ -931,6 +960,14 @@ class EELSSpectrum(Signal1D):
                 ]
             )
         ]
+        if ssd:
+            # Divide by the ZLP area I₀ = ∫Z(E)dE to recover S(E).
+            # For binned data (counts/channel): I₀ = Σ zlp.data.
+            # For density data (counts/eV):     I₀ = Σ zlp.data · Δε.
+            i0 = np.sum(zlp.data, axis=axis.index_in_array, keepdims=True)
+            if not self.axes_manager.signal_axes[0].is_binned:
+                i0 = i0 * axis.scale
+            s.data = s.data / i0
         if add_zlp is True:
             if self_size >= zlp_size:
                 if self._lazy:

--- a/exspy/signals/_eels.py
+++ b/exspy/signals/_eels.py
@@ -907,7 +907,7 @@ class EELSSpectrum(Signal1D):
             scattering component normalised to the ZLP integral (sum
             equals :math:`I_0 \\cdot t/\\lambda`).
             If True, divides by :math:`I_0` to recover the single-
-             scattering distribution (sum equals :math:`t/\\lambda`).
+            scattering distribution (sum equals :math:`t/\\lambda`).
 
         Returns
         -------
@@ -924,6 +924,29 @@ class EELSSpectrum(Signal1D):
         -----
         For details see: Egerton, R. *Electron Energy-Loss Spectroscopy in
         the Electron Microscope*.  Springer-Verlag, 2011, §4.4.
+
+        .. warning::
+
+           **Quantification pitfall.**  When using the default output
+           :math:`J^1(E)` for elemental quantification, the edge integral
+           includes the factor :math:`I_0`.  The areal density of element
+           *k* must be computed as
+
+               :math:`N_k = \\int_\\text{edge} J^1(E)\\,dE \\,/\\, (I_0 \\cdot \\sigma_k)`
+
+           where :math:`\\sigma_k` is the partial cross-section.  Omitting
+           :math:`I_0` overestimates the areal density by the factor
+           :math:`I_0` (typically :math:`10^4`–:math:`10^6`).
+
+           To avoid this, either supply :math:`I_0` separately (from
+           ``zlp.data.sum()`` or
+           :meth:`estimate_elastic_scattering_intensity`) **or** pass
+           ``ssd=True`` to obtain :math:`S(E)` directly, for which
+
+               :math:`N_k = \\int_\\text{edge} S(E)\\,dE \\,/\\, \\sigma_k`
+
+           holds without further normalisation.  See the user guide for an
+           extended discussion.
 
         """
         import dask.array as da
@@ -969,6 +992,11 @@ class EELSSpectrum(Signal1D):
                 i0 = i0 * axis.scale
             s.data = s.data / i0
         if add_zlp is True:
+            # When returning the SSD (ssd=True) the output is normalised to
+            # I₀, so the ZLP must share that normalisation to keep consistent
+            # units.  When returning J¹(E) (ssd=False) the raw ZLP, which is
+            # already in counts, can be added directly.
+            zlp_add = zlp.data / i0 if ssd else zlp.data
             if self_size >= zlp_size:
                 if self._lazy:
                     _slices_before = s.axes_manager._get_data_slice(
@@ -982,7 +1010,7 @@ class EELSSpectrum(Signal1D):
                         ]
                     )
                     s.data = da.stack(
-                        (s.data[_slices_before] + zlp.data, s.data[_slices_after]),
+                        (s.data[_slices_before] + zlp_add, s.data[_slices_after]),
                         axis=axis.index_in_array,
                     )
                 else:
@@ -992,9 +1020,9 @@ class EELSSpectrum(Signal1D):
                                 (axis.index_in_array, slice(None, zlp_size)),
                             ]
                         )
-                    ] += zlp.data
+                    ] += zlp_add
             else:
-                s.data += zlp.data[
+                s.data += zlp_add[
                     s.axes_manager._get_data_slice(
                         [
                             (axis.index_in_array, slice(None, self_size)),

--- a/exspy/tests/signals/test_eels.py
+++ b/exspy/tests/signals/test_eels.py
@@ -658,3 +658,124 @@ class TestVacuumMask:
         s2 = s.sum()
         with pytest.raises(RuntimeError):
             s2.vacuum_mask()
+
+
+class TestFourierLogDeconvolution:
+    """Tests for the ``ssd`` parameter of fourier_log_deconvolution."""
+
+    def setup_method(self, method):
+        from hyperspy.misc.math_tools import optimal_fft_size
+
+        scale = 0.5
+        offset = -25.0
+        n = 1401  # -25 to 675 eV
+        energy = np.linspace(offset, offset + (n - 1) * scale, n)
+
+        # Narrow Gaussian ZLP at E=0 — σ=0.1 eV so convolution z⊗s ≈ I₀·s
+        zlp_data = self._gaussian(energy, centre=0.0, sigma=0.1, area=1000.0)
+        zlp = exspy.signals.EELSSpectrum(zlp_data)
+        zlp.axes_manager[-1].scale, zlp.axes_manager[-1].offset = scale, offset
+        zlp.axes_manager[-1].units, zlp.axes_manager[-1].name = "eV", "Energy loss"
+        self.I0 = zlp_data.sum()
+
+        # SSD: Gaussian plasmon at 16.7 eV with t/λ = 0.3
+        ssd_data = self._gaussian(energy, centre=16.7, sigma=1.5, area=0.3)
+        self.t_over_lambda = ssd_data.sum()
+
+        # Forward model J(ν) = Z(ν)·exp(S(ν)) — the Poisson model that the
+        # deconvolution formula z·log(j/z) is designed to invert.
+        # Signals must be rolled E=0→index0 before FFT to prevent phase
+        # errors that would displace the convolution peak by k₀ channels.
+        k0 = int(round((0.0 - offset) / scale))
+        size = optimal_fft_size(2 * n)
+        z_rolled = np.roll(zlp_data, -k0)
+        s_rolled = np.roll(ssd_data, -k0)
+        z_f = np.fft.rfft(z_rolled, n=size)
+        s_f = np.fft.rfft(s_rolled, n=size)
+        j_data = np.roll(np.fft.irfft(z_f * np.exp(s_f))[:n], k0)
+
+        j = exspy.signals.EELSSpectrum(j_data)
+        j.axes_manager[-1].scale, j.axes_manager[-1].offset = scale, offset
+        j.axes_manager[-1].units, j.axes_manager[-1].name = "eV", "Energy loss"
+
+        self.zlp = zlp
+        self.j = j
+        self.ssd_ref = ssd_data
+        self.energy = energy
+
+    @staticmethod
+    def _gaussian(x, centre, sigma, area):
+        """Return a Gaussian on *x* with the given area."""
+        return (area / (sigma * np.sqrt(2 * np.pi))) * np.exp(
+            -0.5 * ((x - centre) / sigma) ** 2
+        )
+
+    def test_ssd_false_returns_j1(self):
+        """ssd=False (default) returns J¹(E) with sum ≈ I₀·t/λ."""
+        result = self.j.fourier_log_deconvolution(zlp=self.zlp, ssd=False)
+        integral = result.data.sum()
+        expected = self.I0 * self.t_over_lambda
+        assert np.isclose(integral, expected, rtol=0.01), (
+            f"J¹ sum {integral:.3f} ≠ I₀·t/λ = {expected:.3f}"
+        )
+
+    def test_ssd_true_returns_ssd(self):
+        """ssd=True returns S(E) with sum ≈ t/λ."""
+        result = self.j.fourier_log_deconvolution(zlp=self.zlp, ssd=True)
+        integral = result.data.sum()
+        assert np.isclose(integral, self.t_over_lambda, rtol=0.01), (
+            f"SSD sum {integral:.3f} ≠ t/λ = {self.t_over_lambda:.3f}"
+        )
+
+    def test_j1_equals_i0_times_ssd(self):
+        """J¹(E) / I₀ should equal S(E)."""
+        j1 = self.j.fourier_log_deconvolution(zlp=self.zlp, ssd=False)
+        ssd = self.j.fourier_log_deconvolution(zlp=self.zlp, ssd=True)
+        ratio = (j1.data.sum() / self.I0) / ssd.data.sum()
+        assert np.isclose(ratio, 1.0, rtol=0.01), f"J¹/I₀ / S = {ratio:.4f} ≠ 1.0"
+
+    def test_ssd_recovers_plasmon_peak(self):
+        """The plasmon peak position and shape are recovered for both modes."""
+        ssd_out = self.j.fourier_log_deconvolution(zlp=self.zlp, ssd=True)
+        energy = ssd_out.axes_manager[-1].axis
+
+        mask = (energy > 0) & (energy < 50)
+        corr = np.corrcoef(self.ssd_ref[mask], ssd_out.data[mask])[0, 1]
+        assert corr > 0.99, f"Plasmon correlation {corr:.4f} < 0.99"
+
+    def test_add_zlp_j1_raw_zlp(self):
+        """add_zlp=True with ssd=False adds raw ZLP (counts)."""
+        result = self.j.fourier_log_deconvolution(zlp=self.zlp, add_zlp=True, ssd=False)
+        i0 = self.zlp.data.sum()
+        # J¹ integral = I₀·t/λ, ZLP integral = I₀ → total = I₀·(t/λ + 1)
+        expected = i0 * self.t_over_lambda + i0
+        assert np.isclose(result.data.sum(), expected, rtol=0.02), (
+            f"J¹+ZLP sum {result.data.sum():.3f} ≠ I₀·(t/λ+1) = {expected:.3f}"
+        )
+
+    def test_add_zlp_with_ssd(self):
+        """add_zlp=True with ssd=True scales the ZLP by 1/I₀."""
+        result = self.j.fourier_log_deconvolution(zlp=self.zlp, add_zlp=True, ssd=True)
+        i0 = self.zlp.data.sum()
+        # SSD integral = t/λ, normalized ZLP integral = 1 → total = t/λ + 1
+        assert np.isclose(result.data.sum(), self.t_over_lambda + 1.0, rtol=0.02), (
+            f"SSD+ZLP sum {result.data.sum():.3f} ≠ t/λ+1 = {self.t_over_lambda + 1.0:.3f}"
+        )
+        # The deconvolution output plus normalized ZLP should match the
+        # ssd=False add_zlp=True output divided by I₀ everywhere except
+        # in the Hanning-taper region.
+        result_j1 = self.j.fourier_log_deconvolution(
+            zlp=self.zlp, add_zlp=True, ssd=False
+        )
+        # Skip first/last 100 channels (Hanning taper)
+        n = self.j.axes_manager[-1].size
+        compare = slice(100, n - 100)
+        expected = result_j1.data[compare] / i0
+        assert np.allclose(result.data[compare], expected, rtol=0.001), (
+            "SSD add_zlp output ≠ J¹ add_zlp output / I₀ outside taper region"
+        )
+
+    def test_crop(self):
+        """crop=True works with ssd=True."""
+        result = self.j.fourier_log_deconvolution(zlp=self.zlp, crop=True, ssd=True)
+        assert result.axes_manager[-1].size < self.j.axes_manager[-1].size

--- a/upcoming_changes/168.enhancements.rst
+++ b/upcoming_changes/168.enhancements.rst
@@ -1,0 +1,1 @@
+Add ``ssd`` parameter to :meth:`~.signals.EELSSpectrum.fourier_log_deconvolution` to optionally return the normalised single-scattering distribution ``S(E)`` instead of the default ``J¹(E) = I₀ · S(E)``.


### PR DESCRIPTION
### Description

Adds an `ssd` parameter to `fourier_log_deconvolution` that optionally returns the normalised single-scattering distribution `S(E)` instead of the default `J^1(E) = I₀ · S(E)`.

| Parameter | Returns | Integral | Use case |
|---|---|---|---|
| `ssd=False` (default) | `J¹(E)` | `I₀ · t/λ` | Backward-compatible; relative quantification |
| `ssd=True` | `S(E)` | `t/λ` | Absolute quantification (no I₀ needed) |

#### Additional fixes
- **`add_zlp` scaling**: When `add_zlp=True` with `ssd=True`, the ZLP is now correctly scaled by `1/I₀` to match SSD normalisation. Previously raw ZLP counts were added, producing nonsense output 7–9 orders of magnitude too large.
- **Docstring**: Added quantification-pitfall warning explaining that `J¹(E)` must be divided by `I₀` for areal-density quantification.

#### Changes
- `exspy/signals/_eels.py` — `ssd` parameter + `add_zlp` scaling fix + docstring warning
- `exspy/tests/signals/test_eels.py` — 7 new tests in `TestFourierLogDeconvolution`
- `doc/user_guide/eels.rst` — expanded Deconvolutions section
- `upcoming_changes/168.enhancements.rst` — towncrier changelog

#### Test results
- 7/7 new deconvolution tests pass
- 622/627 pass suite-wide (5 pre-existing `two_area_powerlaw_estimation*` failures unrelated to this PR)

#### References
- Egerton, R.F. *Electron Energy-Loss Spectroscopy in the Electron Microscope*. Springer, 2011, §4.4.