### PR TITLE
Increase tolerance tests following changes in component parameters estimation

### DIFF
--- a/exspy/tests/models/test_eelsmodel.py
+++ b/exspy/tests/models/test_eelsmodel.py
@@ -216,8 +216,9 @@ class TestEELSModel:
         self.m.signal.data = 2.0 * self.m.axis.axis ** (-3)  # A= 2, r=3
         # self.m.signal.axes_manager[-1].is_binned = False
         self.m.two_area_background_estimation()
+        # increase rtol following https://github.com/hyperspy/hyperspy/pull/3381
         np.testing.assert_allclose(
-            self.m._background_components[0].A.value, 2.1451237089380295
+            self.m._background_components[0].A.value, 2.1451237089380295, rtol=5e-3
         )
         np.testing.assert_allclose(
             self.m._background_components[0].r.value, 3.0118980767392736
@@ -228,8 +229,9 @@ class TestEELSModel:
         self.m.signal.data = 2.0 * self.m.axis.axis ** (-3)  # A= 2, r=3
         # self.m.signal.axes_manager[-1].is_binned = False
         self.m.two_area_background_estimation()
+        # increase rtol following https://github.com/hyperspy/hyperspy/pull/3381
         np.testing.assert_allclose(
-            self.m._background_components[0].A.value, 2.3978438900878087
+            self.m._background_components[0].A.value, 2.3978438900878087, rtol=2e-2
         )
         np.testing.assert_allclose(
             self.m._background_components[0].r.value, 3.031884021065014
@@ -242,8 +244,9 @@ class TestEELSModel:
         print(self.m.signal.axes_manager[-1].is_binned)
         # self.m.signal.axes_manager[-1].is_binned = False
         self.m.two_area_background_estimation()
+        # increase rtol following https://github.com/hyperspy/hyperspy/pull/3381
         np.testing.assert_allclose(
-            self.m._background_components[0].A.value, 2.6598803469440986
+            self.m._background_components[0].A.value, 2.6598803469440986, rtol=5e-2
         )
         np.testing.assert_allclose(
             self.m._background_components[0].r.value, 3.0494030409062058


### PR DESCRIPTION
The parameters estimation changes slightly in https://github.com/hyperspy/hyperspy/pull/3381 and the tests in exspy are now failing. This PR increases the tolerance failure to get the tests to pass.

From https://github.com/hyperspy/hyperspy-extensions-list/issues/106:
```python
tests/models/test_eelsmodel.py::TestEELSModel::test_two_area_powerlaw_estimation_BC: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.00039216
Max relative difference among violations: 0.00018281
 ACTUAL: array(2.144732)
 DESIRED: array(2.145124)
tests/models/test_eelsmodel.py::TestEELSModel::test_two_area_powerlaw_estimation_C: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.01379775
Max relative difference among violations: 0.00575423
 ACTUAL: array(2.384046)
 DESIRED: array(2.397844)
tests/models/test_eelsmodel.py::TestEELSModel::test_two_area_powerlaw_estimation_no_edge: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.0392076
Max relative difference among violations: 0.01474036
 ACTUAL: array(2.620673)
 DESIRED: array(2.65988)
tests/models/test_eelsmodel.py::TestEELSModel::test_lazy_two_area_powerlaw_estimation_BC: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.00039216
Max relative difference among violations: 0.00018281
 ACTUAL: array(2.144732)
 DESIRED: array(2.145124)
tests/models/test_eelsmodel.py::TestEELSModel::test_lazy_two_area_powerlaw_estimation_C: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.01379775
Max relative difference among violations: 0.00575423
 ACTUAL: array(2.384046)
 DESIRED: array(2.397844)
tests/models/test_eelsmodel.py::TestEELSModel::test_lazy_two_area_powerlaw_estimation_no_edge: AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 0.0392076
Max relative difference among violations: 0.01474036
 ACTUAL: array(2.620673)
 DESIRED: array(2.65988)
```

### Progress of the PR
- [x] Increase tolerance,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] update tests,
- [n/a] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/exspy/blob/main/upcoming_changes/README.rst)),
- [n/a] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:exspy` build of this PR (link in github checks)
- [x] ready for review.

